### PR TITLE
Feat - OAuth2 : 로그인 구현 (Google, Naver, Kakao)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies{
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,13 @@ repositories {
 
 dependencies{
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
@@ -41,6 +46,7 @@ dependencies{
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -1,0 +1,56 @@
+package com.minwonhaeso.esc.member.model.entity;
+
+import com.minwonhaeso.esc.member.model.type.MemberRole;
+import com.minwonhaeso.esc.member.model.type.MemberStatus;
+import com.minwonhaeso.esc.member.model.type.MemberType;
+import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+import com.sun.istack.NotNull;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "member")
+@Getter
+@Builder
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(unique = true, name = "email")
+    private String email;
+
+    @NotNull
+    @Column(name = "name")
+    private String name;
+
+    @NotNull
+    @Column(name = "password")
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(unique = true)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private MemberType type;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private ProviderType providerType; // 소셜 타입
+
+    @Column(name = "provider_id")
+    private String providerId;
+}

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberRole.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberRole.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.member.model.type;
+
+public enum MemberRole {
+    ROLE_MANAGER, ROLE_USER
+}

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberStatus.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.member.model.type;
+
+public enum MemberStatus {
+    AVAILABLE, BANNED, WITHDRAW
+}

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.member.model.type;
+
+public enum MemberType {
+    USER, ADMIN
+}

--- a/src/main/java/com/minwonhaeso/esc/member/repository/MemberRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.minwonhaeso.esc.member.repository;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+//    @Query("select m from Member m join fetch m.role a where m.name = :name")
+//    Optional<Member> findByNameWithRole(String name);
+
+    Optional<Member> findByName(String username);
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/minwonhaeso/esc/security/SecurityConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/security/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.minwonhaeso.esc.security;
+
+import com.minwonhaeso.esc.security.oauth2.service.CustomerOAuth2MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity(debug = false)
+@EnableGlobalMethodSecurity(securedEnabled = true)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CustomerOAuth2MemberService oAuth2UserService;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.csrf().disable();
+        http.oauth2Login()
+                .authorizationEndpoint()
+                .baseUri("/oauth2/authorization")
+                .and()
+                .userInfoEndpoint()
+                .userService(oAuth2UserService);
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetails.java
@@ -1,0 +1,81 @@
+package com.minwonhaeso.esc.security.auth;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class PrincipalDetails implements UserDetails, OAuth2User {
+
+    private final Member member;
+    private Map<String, Object> attributes;
+
+    // 일반 로그인
+    public PrincipalDetails(Member member) {
+        this.member = member;
+    }
+
+    // OAuth 로그인
+    public PrincipalDetails(Member member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collect = new ArrayList<>();
+        collect.add( new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return member.getRole().toString();
+            }
+        });
+        return collect;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/info/OAuth2MemberInfo.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/info/OAuth2MemberInfo.java
@@ -1,0 +1,14 @@
+package com.minwonhaeso.esc.security.oauth2.info;
+
+import java.util.Map;
+
+public interface OAuth2MemberInfo {
+
+    Map<String, Object> getAttributes();
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+
+    String getImageUrl();
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/info/OAuth2MemberInfoFactory.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/info/OAuth2MemberInfoFactory.java
@@ -1,0 +1,19 @@
+package com.minwonhaeso.esc.security.oauth2.info;
+
+import com.minwonhaeso.esc.security.oauth2.info.provider.GoogleMemberInfo;
+import com.minwonhaeso.esc.security.oauth2.info.provider.KakaoMemberInfo;
+import com.minwonhaeso.esc.security.oauth2.info.provider.NaverMemberInfo;
+import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+
+import java.util.Map;
+
+public class OAuth2MemberInfoFactory {
+    public static OAuth2MemberInfo getOAuth2MemberInfo(ProviderType providerType, Map<String, Object> attributes) {
+        switch (providerType) {
+            case GOOGLE: return new GoogleMemberInfo(attributes);
+            case NAVER: return new NaverMemberInfo(attributes);
+            case KAKAO: return new KakaoMemberInfo(attributes);
+            default: throw new IllegalArgumentException("Invalid Provider Type");
+        }
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/GoogleMemberInfo.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/GoogleMemberInfo.java
@@ -1,0 +1,46 @@
+package com.minwonhaeso.esc.security.oauth2.info.provider;
+
+
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
+
+import java.util.Map;
+
+public class GoogleMemberInfo implements OAuth2MemberInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleMemberInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+
+    @Override
+    public String getImageUrl() {
+        return attributes.get("picture").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "Google";
+    }
+
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/KakaoMemberInfo.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/KakaoMemberInfo.java
@@ -1,0 +1,48 @@
+package com.minwonhaeso.esc.security.oauth2.info.provider;
+
+
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
+
+import java.util.Map;
+
+public class KakaoMemberInfo implements OAuth2MemberInfo {
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> attributesAccount;
+    private final Map<String, Object> attributesProfile;
+
+    public KakaoMemberInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.attributesAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.attributesProfile = (Map<String, Object>) attributesAccount.get("profile");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributesAccount.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributesProfile.get("nickname").toString();
+    }
+
+    @Override
+    public String getImageUrl() {
+        return attributesProfile.get("thumbnail_image_url").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "Kakao";
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/NaverMemberInfo.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/info/provider/NaverMemberInfo.java
@@ -1,0 +1,44 @@
+package com.minwonhaeso.esc.security.oauth2.info.provider;
+
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
+
+import java.util.Map;
+
+public class NaverMemberInfo implements OAuth2MemberInfo {
+
+    private final Map<String, Object> attributes;
+
+    public NaverMemberInfo(Map<String, Object> attributes) {
+        this.attributes = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+
+    @Override
+    public String getImageUrl() {
+        return attributes.get("profile_image").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "Naver";
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerMemberDetailsService.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerMemberDetailsService.java
@@ -1,0 +1,25 @@
+package com.minwonhaeso.esc.security.oauth2.service;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerMemberDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
+        Optional<Member> memberEntity = memberRepository.findByName(name);
+
+        return memberEntity.map(PrincipalDetails::new).orElse(null);
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
@@ -1,0 +1,98 @@
+package com.minwonhaeso.esc.security.oauth2.service;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.model.type.MemberRole;
+import com.minwonhaeso.esc.member.model.type.MemberStatus;
+import com.minwonhaeso.esc.member.model.type.MemberType;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.security.auth.PrincipalDetails;
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;
+import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class CustomerOAuth2MemberService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        try {
+            return this.processOAuth2User(userRequest, oAuth2User);
+        } catch (AuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+
+        ProviderType providerType = ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+        OAuth2MemberInfo oAuth2MemberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(providerType, oAuth2User.getAttributes());
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(oAuth2MemberInfo.getEmail());
+        Member member;
+
+        if (optionalMember.isPresent()) {
+            member = optionalMember.get();
+
+//            TODO - 기존에 OAUTH로 가입한 providerType이 다를 경우 예외 처리
+//            if (!member.getProviderType().equals(providerType)) {
+//                throw new RuntimeException();
+//            }
+
+//            member = updateMember(member, oAuth2UserInfo);
+
+        } else {
+            member = registerMember(oAuth2MemberInfo, providerType);
+        }
+
+        log.info("processOAuth2User :" + member);
+        return new PrincipalDetails(member, oAuth2User.getAttributes());
+    }
+
+    private Member registerMember(OAuth2MemberInfo oAuth2MemberInfo, ProviderType providerType) {
+
+        String uuid = UUID.randomUUID().toString().substring(0, 6);
+
+        return memberRepository.saveAndFlush(Member.builder()
+                .email(oAuth2MemberInfo.getEmail())
+                .name(oAuth2MemberInfo.getName())
+                .nickname(providerType+"_"+ oAuth2MemberInfo.getProviderId())
+                .password(BCrypt.hashpw("esc" + uuid, BCrypt.gensalt()))
+                .role(MemberRole.ROLE_USER)
+                .providerType(providerType)
+                .status(MemberStatus.AVAILABLE)
+                .type(MemberType.USER)
+                .providerId(oAuth2MemberInfo.getProviderId())
+                .imgUrl(oAuth2MemberInfo.getImageUrl())
+                .build());
+    }
+
+//    TODO - OAUTH2_정보 수정
+//    private Member updateMember(Member member, OAuth2UserInfo oAuth2UserInfo) {
+//        member.updateName(oAuth2UserInfo.getName());
+//        member.updateImageUrl(oAuth2UserInfo.getImageUrl());
+//
+//        return memberRepository.save(member);
+//    }
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/type/ProviderType.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/type/ProviderType.java
@@ -1,0 +1,8 @@
+package com.minwonhaeso.esc.security.oauth2.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ProviderType {
+    GOOGLE, NAVER, KAKAO, LOCAL;
+}


### PR DESCRIPTION
Background
---
소셜 회원가입 및 로그인을 사용하기로 하여 OAuth2를 사용하였습니다.

Change
---
OAuth2 - Google, Naver, Kakao 세 종류의 소셜 로그인 구현

Test
---
서버 실행 후, 통신 테스트 검증하였습니다.

Analatics
---
SecurityConfig 관련하여 OAuth2 쪽 success & failure Handler 구현도 필요한지 찾아보고 있습니다. 기본 로그인과 소셜 로그인 시의 토큰 관리 부분에 대해 얘기해봐야할 것 같습니다!

Discuss
---
아직 계속해서 다듬고 있는 단계이지만, 기본적인 기능 구현은 완료한 상태라 PR 올립니다! 리뷰 부탁드릴게요!