### PR TITLE
Feat - Stadium : 체육관 아이템 등록/추가/삭제 구현

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumController.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.stadium.dto.CreateStadiumDto;
+import com.minwonhaeso.esc.stadium.dto.CreateStadiumItemDto;
 import com.minwonhaeso.esc.stadium.dto.StadiumResponseDto;
 import com.minwonhaeso.esc.stadium.dto.UpdateStadiumDto;
 import com.minwonhaeso.esc.stadium.service.StadiumService;
@@ -31,13 +32,17 @@ public class StadiumController {
 
     @PostMapping("/register")
     public ResponseEntity<?> createStadiumByManager(
-            @RequestBody CreateStadiumDto.Request request) {
+            @RequestBody CreateStadiumDto.Request request
+    ) {
         CreateStadiumDto.Response stadium = stadiumService.createStadium(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(stadium);
     }
 
     @PatchMapping("/{stadiumId}/info")
-    public ResponseEntity<?> updateStadiumInfo(@PathVariable Long stadiumId, UpdateStadiumDto.Request request) {
+    public ResponseEntity<?> updateStadiumInfo(
+            @PathVariable Long stadiumId,
+            UpdateStadiumDto.Request request
+    ) {
         StadiumResponseDto stadium = stadiumService.updateStadiumInfo(stadiumId, request);
         return ResponseEntity.ok().body(stadium);
     }
@@ -60,10 +65,20 @@ public class StadiumController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/{stadiumId}/items")
+    public ResponseEntity<?> addStadiumItemByManager(
+            @PathVariable Long stadiumId,
+            @RequestBody CreateStadiumItemDto.Request request
+    )  {
+        CreateStadiumItemDto.Response item = stadiumService.addStadiumItem(stadiumId, request);
+        return ResponseEntity.ok().body(item);
+    }
+
     @DeleteMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> deleteStadiumImgByManager(
             @PathVariable Long stadiumId,
-            @RequestBody UpdateStadiumDto.DeleteImgRequest request) {
+            @RequestBody UpdateStadiumDto.DeleteImgRequest request
+    ) {
         stadiumService.deleteStadiumImg(stadiumId, request.getImgUrl());
         return ResponseEntity.ok().build();
     }
@@ -71,11 +86,19 @@ public class StadiumController {
     @DeleteMapping("/{stadiumId}/tags")
     public ResponseEntity<?> deleteStadiumTagByManager(
             @PathVariable Long stadiumId,
-            @RequestBody UpdateStadiumDto.DeleteTagRequest request) {
+            @RequestBody UpdateStadiumDto.DeleteTagRequest request
+    ) {
         stadiumService.deleteStadiumTag(stadiumId, request.getTagName());
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/{stadiumId}/items")
+    public ResponseEntity<?> deleteStadiumItemByManager(
+            @PathVariable Long stadiumId,
+            @RequestBody UpdateStadiumDto.DeleteItemRequest request) {
+        stadiumService.deleteStadiumItem(stadiumId, request);
+        return ResponseEntity.ok().build();
+    }
 
     @DeleteMapping("/{stadiumId}")
     public ResponseEntity<?> deleteStadiumByManager(@PathVariable Long stadiumId) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/dto/CreateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/dto/CreateStadiumDto.java
@@ -1,10 +1,7 @@
 package com.minwonhaeso.esc.stadium.dto;
 
 import com.minwonhaeso.esc.stadium.entity.Stadium;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.sql.Time;
 import java.util.List;
@@ -26,7 +23,7 @@ public class CreateStadiumDto {
         private List<String> tags;
         private Time openTime;
         private Time closeTime;
-//        private List<Item> items; // TODO: 아이템 추가
+        private List<CreateStadiumItemDto.Request> items;
     }
 
     @Getter

--- a/src/main/java/com/minwonhaeso/esc/stadium/dto/CreateStadiumItemDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/dto/CreateStadiumItemDto.java
@@ -1,0 +1,24 @@
+package com.minwonhaeso.esc.stadium.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class CreateStadiumItemDto {
+    @Data
+    public static class Request {
+        private String name;
+        private String imgUrl;
+        private Integer price;
+        private Integer cnt;
+    }
+
+    @Data
+    @Builder
+    public static class Response {
+        private String name;
+        private String imgUrl;
+        private Integer price;
+        private Integer cnt;
+        private boolean isAvailable;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/dto/UpdateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/dto/UpdateStadiumDto.java
@@ -41,4 +41,9 @@ public class UpdateStadiumDto {
     public static class DeleteTagRequest {
         private String tagName;
     }
+
+    @Data
+    public static class DeleteItemRequest {
+        private Long itemId;
+    }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/entity/Stadium.java
@@ -1,5 +1,6 @@
 package com.minwonhaeso.esc.stadium.entity;
 
+import com.minwonhaeso.esc.stadium.dto.CreateStadiumDto;
 import com.minwonhaeso.esc.stadium.dto.UpdateStadiumDto;
 import com.sun.istack.NotNull;
 import lombok.*;
@@ -76,9 +77,9 @@ public class Stadium {
 //    @Column(name = "likes")
 //    private List<Like> likes;
 
-//    @OneToMany(mappedBy = "stadium")
-//    @Column(name = "rental_items")
-//    private List<Item> rentalItems;
+    @OneToMany(mappedBy = "stadium")
+    @Column(name = "rental_items")
+    private List<StadiumItem> rentalStadiumItems;
 
     @Builder.Default
     @OneToMany(mappedBy = "stadium")
@@ -107,6 +108,20 @@ public class Stadium {
         if (this.imgs == null) {
             this.imgs = new ArrayList<>();
         }
+    }
+
+    public static Stadium fromRequest(CreateStadiumDto.Request request) {
+        return Stadium.builder()
+                .name(request.getName())
+                .phone(request.getPhone())
+                .lat(request.getLat())
+                .lnt(request.getLnt())
+                .address(request.getAddress())
+                .weekdayPricePerHalfHour(request.getWeekdayPricePerHalfHour())
+                .holidayPricePerHalfHour(request.getHolidayPricePerHalfHour())
+                .openTime(request.getOpenTime())
+                .closeTime(request.getCloseTime())
+                .build();
     }
 
     public void update(UpdateStadiumDto.Request request) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/entity/StadiumItem.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/entity/StadiumItem.java
@@ -1,0 +1,64 @@
+package com.minwonhaeso.esc.stadium.entity;
+
+import com.minwonhaeso.esc.stadium.dto.CreateStadiumItemDto;
+import com.minwonhaeso.esc.stadium.type.StadiumItemStatus;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+import static com.minwonhaeso.esc.stadium.type.StadiumItemStatus.AVAILABLE;
+import static javax.persistence.EnumType.STRING;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StadiumItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "item_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "stadium_id")
+    private Stadium stadium;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Column(name = "cnt", nullable = false)
+    private Integer cnt;
+
+    @Enumerated(STRING)
+    private StadiumItemStatus status;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public static StadiumItem fromRequest(Stadium stadium, CreateStadiumItemDto.Request request) {
+        return StadiumItem.builder()
+                .name(request.getName())
+                .stadium(stadium)
+                .imgUrl(request.getImgUrl())
+                .price(request.getPrice())
+                .cnt(request.getCnt())
+                .status(AVAILABLE)
+                .build();
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
@@ -1,0 +1,8 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.stadium.entity.StadiumItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StadiumItemRepository extends JpaRepository<StadiumItem, Long> {
+    void deleteByStadiumIdAndId(Long stadiumId, Long itemId);
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/type/StadiumItemStatus.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/type/StadiumItemStatus.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.stadium.type;
+
+public enum StadiumItemStatus {
+    AVAILABLE, UNAVAILABLE
+}


### PR DESCRIPTION
Background
---
- 일단은 아이템 대여를 별도의 서비스로 뺄지에 대해서 아직 정해지지 않아서 Stadium도메인 안에서 작업을 했습니다!

Change
---
- 기존 Stadium 등록 로직에 Item을 넣는 기능을 추가했습니다
- Stadium Id와 함께 Item을 추가등록하거나 삭제하는 기능을 추가했습니다

Test
---
- Stadium쪽 CRUD 작업이 어느정도 완성돼서 한꺼번에 http test를 진행하려고 합니다!
- IntelliJ의 http 파일을 통해서 작업하고 테스트 코드들을 같이 깃허브에 올리겠습니다!

Analytics
---
- 이미지, 태그, 아이템에 대해서 하나씩 삭제하고 추가하는 API를 작성했는데 이부분이 프론트와 백엔드 모두 효율적으로 작동할지는 미지수여서 멘토님께 질문드리기로 재원님이랑 상의를 했습니다! 질문 후에 노션에 공유하겠습니다!

Discuss
---
- 이미지와 태그 추가 삭제쪽과 거의 같은 로직으로 작성했기 때문에 오탈자나 코드 전체적인 흐름부분에서 리뷰 부탁드립니다!
- 체육관에도 인증 권한쪽 처리가 연결되려면 저도 인증쪽에서 어느정도 코드를 알아야 할 것 같아서 재원님이 프론트 페이지 작업하실 동안 Spring Security Oauth2쪽 소아님이랑 같이 고민해보겠습니다!