### PR TITLE
Feat - Auth 이메일 인증 방식 변경

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/common/swagger/SwaggerConfig.java
@@ -2,9 +2,7 @@ package com.minwonhaeso.esc.common.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -14,7 +12,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 @EnableWebMvc
-public class SwaggerConfig{
+public class SwaggerConfig {
 
     @Bean
     public Docket restAPI() {

--- a/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
@@ -15,7 +15,8 @@ public enum AuthErrorCode {
     PasswordNotEqual(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     MemberNotLogIn(HttpStatus.BAD_REQUEST, "로그인을 해주세요."),
     AccessTokenAlreadyExpired(HttpStatus.BAD_REQUEST, "인증이 만료되었습니다. 다시 로그인해주세요."),
-    TokenNotMatch(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다.");
+    TokenNotMatch(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다."),
+    AuthKeyNotMatch(HttpStatus.CONFLICT, "인증 코드가 맞지 않습니다.");
 
 
 

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -51,7 +51,7 @@ public class MemberController {
      **/
     @PostMapping("/email-authentication")
     public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
-        String authKey = memberService.emailAuthentication(key);
+        memberService.emailAuthentication(key);
         return ResponseEntity.ok("메일 인증이 완료되었습니다.");
     }
 

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import javax.naming.AuthenticationException;
 import java.util.Map;
 
 @RestController
@@ -35,24 +34,39 @@ public class MemberProfileController {
         return ResponseEntity.ok(memberService.patchInfo(userDetails, request));
     }
 
+    /**
+     * 회원 탈퇴
+     **/
     @DeleteMapping("/info")
     public ResponseEntity<?> delete(@AuthenticationPrincipal UserDetails userDetails) {
         memberService.deleteMember(userDetails);
         return ResponseEntity.ok("탈퇴에 성공했습니다.");
     }
+
+    /**
+     * 비밀번호 변경 메일 전송
+     **/
     @PostMapping("/password/send-mail")
-    public ResponseEntity<?> changePasswordMail(@RequestBody Map<String, String> body){
+    public ResponseEntity<?> changePasswordMail(@RequestBody Map<String, String> body) {
         String email = body.get("email");
         memberService.changePasswordMail(email);
         return ResponseEntity.ok("메일이 발송되었습니다.");
     }
+
+    /**
+     * 비밀번호 변경 메일 인증코드 확인
+     **/
     @GetMapping("/password")
-    public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key){
-        String email =  memberService.changePasswordMailAuth(key);
+    public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key) {
+        memberService.changePasswordMailAuth(key);
         return ResponseEntity.ok("메일 인증이 완료되었습니다.");
     }
+
+    /**
+     * 비밀번호 변경
+     **/
     @PostMapping("/password")
-    public ResponseEntity<?> changePassword(@RequestBody CPasswordDto.Request request) throws AuthenticationException {
+    public ResponseEntity<?> changePassword(@RequestBody CPasswordDto.Request request) {
         memberService.changePassword(request);
         return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
     }

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/MemberEmail.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/MemberEmail.java
@@ -22,8 +22,6 @@ public class MemberEmail {
 
     private String email;
 
-    private boolean authYn;
-
     @TimeToLive
     private Long expireDt;
 
@@ -32,7 +30,6 @@ public class MemberEmail {
                 .id(authKey)
                 .email(email)
                 .expireDt(emailExpiredTime)
-                .authYn(false)
                 .build();
     }
 


### PR DESCRIPTION
Background
---
Front의 이메일 인증 방식과 Back의 인증 방식이 차이가 있었습니다.

Change
---
인증 url로 인증하는 방법에서 -> 인증 코드를 전송하는 부분으로 바꿨습니다.
개인적인 application.properties 파일에서 메일 주소로 저장한 부분들 지우셔도 될 것 같습니다.

Analatics
---
아직 Token 유/무를 확인하는 필터를 구현해야 합니다.
Discuss
---
필터 구현하는데 좋은 자료가 있으면 공유 부탁드립니다!!