### PR TITLE
Feat - OAuth2 JWT 토큰 발급

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/exception/AuthException.java
+++ b/src/main/java/com/minwonhaeso/esc/error/exception/AuthException.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 
 @Getter
 public class AuthException extends RuntimeException{
-    private final AuthErrorCode errorcode;
+    private final AuthErrorCode errorCode;
 
-    public AuthException(AuthErrorCode errorcode) {
-        super(errorcode.getErrorMessage());
-        this.errorcode = errorcode;
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/minwonhaeso/esc/error/handler/GlobalExceptionHandler.java
@@ -18,9 +18,9 @@ public class GlobalExceptionHandler {
 
 
     @ExceptionHandler(AuthException.class)
-    protected ResponseEntity<GlobalErrorResponse> handleStadiumExceptionHandler(AuthException exception) {
+    protected ResponseEntity<GlobalErrorResponse> handleAuthExceptionHandler(AuthException exception) {
         return ResponseEntity
-                .status(exception.getErrorcode().getStatusCode())
-                .body(GlobalErrorResponse.from(exception.getErrorcode().getErrorMessage()));
+                .status(exception.getErrorCode().getStatusCode())
+                .body(GlobalErrorResponse.from(exception.getErrorCode().getErrorMessage()));
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
@@ -15,7 +15,9 @@ public enum AuthErrorCode {
     PasswordNotEqual(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     MemberNotLogIn(HttpStatus.BAD_REQUEST, "로그인을 해주세요."),
     AccessTokenAlreadyExpired(HttpStatus.BAD_REQUEST, "인증이 만료되었습니다. 다시 로그인해주세요."),
-    TokenNotMatch(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다.");
+    TokenNotMatch(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다."),
+
+    OAuthProviderMissMatch(HttpStatus.BAD_REQUEST, "기존에 회원가입한 소셜 타입과 일치하지 않습니다.");
 
 
 

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -82,8 +82,7 @@ public class MemberController {
     public ResponseEntity<?> reissue(@RequestHeader("RefreshToken") String refreshToken) {
         return ResponseEntity.ok(memberService.reissue(refreshToken));
     }
-
-
+    
     /**
      * Bearer 부분 빼는 method
      **/

--- a/src/main/java/com/minwonhaeso/esc/security/SecurityConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/security/SecurityConfig.java
@@ -3,31 +3,36 @@ package com.minwonhaeso.esc.security;
 import com.minwonhaeso.esc.member.service.CustomerMemberDetailsService;
 import com.minwonhaeso.esc.security.auth.jwt.JwtAuthenticationFilter;
 import com.minwonhaeso.esc.security.auth.jwt.JwtEntryPoint;
+import com.minwonhaeso.esc.security.oauth2.handler.OAuth2SuccessHandler;
 import com.minwonhaeso.esc.security.oauth2.service.CustomerOAuth2MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+import org.springframework.web.cors.CorsUtils;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableGlobalMethodSecurity(securedEnabled = true,prePostEnabled = true)
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtEntryPoint jwtEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomerMemberDetailsService customerMemberDetailsService;
     private final CustomerOAuth2MemberService oAuth2UserService;
+
+    private final OAuth2SuccessHandler successHandler;
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -39,7 +44,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         return new BCryptPasswordEncoder();
     }
 
-    // test, h2 db접속을 위한 ignore 메인 코드에는 필요 없음
     @Override
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers("/h2-console/**", "/favicon.ico");
@@ -47,31 +51,39 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.cors().and()
-                .csrf().disable()
-                .authorizeRequests()
-                .antMatchers("/members/signUp","/members/email-dup","/email-auth","/email-authentication").permitAll()
+        http.cors()
                 .and()
-                .exceptionHandling()
-                .authenticationEntryPoint(jwtEntryPoint)
-
+                    .logout().disable()
+                    .sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .logout().disable()
-                .sessionManagement().sessionCreationPolicy(STATELESS)
-
+                    .csrf().disable()
+                    .authorizeRequests()
+                    .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                    .antMatchers("/members/signUp","/members/email-dup","/email-auth","/email-authentication").permitAll()
                 .and()
-                .oauth2Login()
-                .authorizationEndpoint()
-                .baseUri("/oauth2/authorization")
+                    .exceptionHandling()
+                    .authenticationEntryPoint(jwtEntryPoint)
                 .and()
-                .userInfoEndpoint()
-                .userService(oAuth2UserService);
+                    .oauth2Login()
+//                    .defaultSuccessUrl("/")
+                    .successHandler(successHandler)
+                    .authorizationEndpoint()
+                    .baseUri("/oauth2/authorization")
+                .and()
+//                    .redirectionEndpoint()
+//                    .baseUri("*/oauth2/code/*")
+//                .and()
+                    .userInfoEndpoint()
+                    .userService(oAuth2UserService);
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     }
 
     @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(customerMemberDetailsService).passwordEncoder(passwordEncoder());
+    protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
+        authenticationManagerBuilder
+                .userDetailsService(customerMemberDetailsService)
+                .passwordEncoder(passwordEncoder());
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetails.java
@@ -17,12 +17,10 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
     private final Member member;
     private Map<String, Object> attributes;
 
-    // 일반 로그인
     public PrincipalDetails(Member member) {
         this.member = member;
     }
 
-    // OAuth 로그인
     public PrincipalDetails(Member member, Map<String, Object> attributes) {
         this.member = member;
         this.attributes = attributes;
@@ -35,7 +33,6 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
     public static UserDetails of(Member member) {
         return new PrincipalDetails(member);
     }
-
 
     @Override
     public String getPassword() {

--- a/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtTokenUtil.java
@@ -59,7 +59,7 @@ public class JwtTokenUtil {
         return doGenerateToken(username, REFRESH_TOKEN_EXPIRATION_TIME.getValue());
     }
 
-    private String doGenerateToken(String email, long expireTime) { // 1
+    private String doGenerateToken(String email, long expireTime) {
         Claims claims = Jwts.claims();
         claims.put("email", email);
 

--- a/src/main/java/com/minwonhaeso/esc/security/auth/redis/CacheConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/redis/CacheConfig.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.security.auth.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +10,8 @@ import org.springframework.data.redis.cache.CacheKeyPrefix;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -19,6 +22,12 @@ import java.time.Duration;
 @RequiredArgsConstructor
 @EnableCaching
 public class CacheConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
 
     @Bean
     public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory){
@@ -39,5 +48,15 @@ public class CacheConfig {
                 .cacheDefaults(configuration)
                 .build();
 
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+
+        RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+        conf.setHostName(this.host);
+        conf.setPort(this.port);
+
+        return new LettuceConnectionFactory(conf);
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,60 @@
+package com.minwonhaeso.esc.security.oauth2.handler;
+
+import com.minwonhaeso.esc.security.auth.jwt.JwtTokenUtil;
+import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
+import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;
+import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${test.url}")
+    private String basicUrl;
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    public OAuth2SuccessHandler(JwtTokenUtil jwtTokenUtil) {
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+        ProviderType providerType = ProviderType.valueOf(authToken.getAuthorizedClientRegistrationId().toUpperCase());
+        OAuth2MemberInfo memberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(providerType, oAuth2User.getAttributes());
+
+        log.info("Generate Token");
+
+        String memberEmail = memberInfo.getEmail();
+
+        String token = jwtTokenUtil.generateAccessToken(memberEmail);
+        RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(memberEmail);
+
+        String targetUrl = makeRedirectUrl(token);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String makeRedirectUrl(String token) {
+        return UriComponentsBuilder.fromUriString(basicUrl+token)
+                .build().toUriString();
+    }
+
+}

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
@@ -1,12 +1,13 @@
 package com.minwonhaeso.esc.security.oauth2.service;
 
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.member.model.type.MemberRole;
 import com.minwonhaeso.esc.member.model.type.MemberStatus;
 import com.minwonhaeso.esc.member.model.type.MemberType;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
 import com.minwonhaeso.esc.security.auth.PrincipalDetails;
-import com.minwonhaeso.esc.security.auth.jwt.JwtTokenUtil;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;
 import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
@@ -30,13 +31,13 @@ import java.util.UUID;
 public class CustomerOAuth2MemberService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
-    private final JwtTokenUtil jwtTokenUtil;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         try {
+            log.info(String.valueOf(userRequest.getAccessToken()));
             return this.processOAuth2User(userRequest, oAuth2User);
         } catch (AuthenticationException ex) {
             throw ex;
@@ -49,58 +50,55 @@ public class CustomerOAuth2MemberService extends DefaultOAuth2UserService {
     private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
 
         ProviderType providerType = ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
-        OAuth2MemberInfo oAuth2MemberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(providerType, oAuth2User.getAttributes());
+        OAuth2MemberInfo memberInfo = OAuth2MemberInfoFactory.getOAuth2MemberInfo(providerType, oAuth2User.getAttributes());
 
-        Optional<Member> optionalMember = memberRepository.findByEmail(oAuth2MemberInfo.getEmail());
+        Optional<Member> savedMember = memberRepository.findByEmail(memberInfo.getEmail());
         Member member;
 
-        if (optionalMember.isPresent()) {
-            member = optionalMember.get();
+        if (savedMember.isPresent()) {
+            member = savedMember.get();
 
-//            TODO - 기존에 OAUTH로 가입한 providerType이 다를 경우 예외 처리
-//            if (!member.getProviderType().equals(providerType)) {
-//                throw new RuntimeException();
-//            }
-
-//            member = updateMember(member, oAuth2UserInfo);
+            if (!member.getProviderType().equals(providerType)) {
+                throw new AuthException(AuthErrorCode.OAuthProviderMissMatch);
+            }
+            updateMember(member, memberInfo);
 
         } else {
-            member = registerMember(oAuth2MemberInfo, providerType);
-            return new PrincipalDetails(member, oAuth2User.getAttributes());
+            member = registerMember(memberInfo, providerType);
         }
 
         log.info("processOAuth2User :" + member);
 
-        // TODO
-        // String accessToken = jwtTokenUtil.generateAccessToken(oAuth2MemberInfo.getEmail());
-        // RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(oAuth2MemberInfo.getEmail());
-
         return new PrincipalDetails(member, oAuth2User.getAttributes());
     }
 
-    private Member registerMember(OAuth2MemberInfo oAuth2MemberInfo, ProviderType providerType) {
+    private Member registerMember(OAuth2MemberInfo memberInfo, ProviderType providerType) {
 
         String uuid = UUID.randomUUID().toString().substring(0, 6);
 
         return memberRepository.saveAndFlush(Member.builder()
-                .email(oAuth2MemberInfo.getEmail())
-                .name(oAuth2MemberInfo.getName())
-                .nickname(providerType+"_"+ oAuth2MemberInfo.getProviderId())
+                .email(memberInfo.getEmail())
+                .name(memberInfo.getName())
+                .nickname(providerType+"_"+ memberInfo.getProviderId())
                 .password(BCrypt.hashpw("esc" + uuid, BCrypt.gensalt()))
                 .role(MemberRole.ROLE_USER)
                 .providerType(providerType)
                 .status(MemberStatus.ING)
                 .type(MemberType.USER)
-                .providerId(oAuth2MemberInfo.getProviderId())
-                .imgUrl(oAuth2MemberInfo.getImageUrl())
+                .providerId(memberInfo.getProviderId())
+                .imgUrl(memberInfo.getImageUrl())
                 .build());
     }
 
-//    TODO - OAUTH2_정보 수정
-//    private Member updateMember(Member member, OAuth2UserInfo oAuth2UserInfo) {
-//        member.updateName(oAuth2UserInfo.getName());
-//        member.updateImageUrl(oAuth2UserInfo.getImageUrl());
-//
-//        return memberRepository.save(member);
-//    }
+    private void updateMember(Member member, OAuth2MemberInfo memberInfo) {
+        if (memberInfo.getName() != null && !memberInfo.getName().equals(memberInfo.getName())) {
+            member.setName(memberInfo.getName());
+        }
+
+        if (memberInfo.getImageUrl() != null && !memberInfo.getImageUrl().equals(memberInfo.getImageUrl())) {
+            member.setImgUrl(memberInfo.getImageUrl());
+        }
+
+        memberRepository.save(member);
+    }
 }


### PR DESCRIPTION
Background
---
Auth 서버가 아닌 애플리케이션 서버에서 토큰 유효성 검사를 하기 위해 OAuth2 로그인 시, 토큰 발급 로직을 추가했다.

Change
---
기존 소셜로그인 로직에 해당 서비스의 api를 호출하기 위해 필요한  token 발급에 대해  1step을 더 추가했다.

Analatics
---
토큰 자체에 들어가는 정보는 기본 회원가입과 동일한 상태이며, 권한 필터 부분 자료 찾아보겠습니다.

Discuss
---
구현한 소셜 로그인 프로세스에 대해 프론트엔드 담당분에게 설명 드린 후, 확인 받은 상태입니다!
아마 연동하는 과정에서 추가적으로 수정하는 로직이 필요할 것으로 예상됩니다.

보다 더 좋은 방법을 알고 계신다면  코멘트 부탁드립니다!
(브랜치는 추후 개발하는 부분부터 최대한 상세하게 나눠 PR 보내겠습니다!)