### PR TITLE
Feat - Stadium : 위도 경도 기반 가까운 체육관 조회(Querydsl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 application.yml
 **/test/http
+generated/

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
+apply plugin: "io.spring.dependency-management"
 group = 'com.minwonhaeso'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
@@ -30,14 +31,20 @@ dependencies{
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.h2database:h2'
-//    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+//    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    compileOnly "com.querydsl:querydsl-core" // querydsl
+    compileOnly "com.querydsl:querydsl-jpa" // querydsl
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '3.0.0'
@@ -46,7 +53,20 @@ dependencies{
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+//    testImplementation 'org.springframework.security:spring-security-test'
+}
+
+def generated='src/main/generated'
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
+
+clean.doLast {
+    file(generated).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/java/com/minwonhaeso/esc/common/config/QuerydslConfiguration.java
+++ b/src/main/java/com/minwonhaeso/esc/common/config/QuerydslConfiguration.java
@@ -1,0 +1,19 @@
+package com.minwonhaeso.esc.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfiguration {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -1,13 +1,11 @@
 package com.minwonhaeso.esc.stadium.controller;
 
-import com.minwonhaeso.esc.stadium.dto.CreateStadiumDto;
-import com.minwonhaeso.esc.stadium.dto.CreateStadiumItemDto;
-import com.minwonhaeso.esc.stadium.dto.StadiumResponseDto;
-import com.minwonhaeso.esc.stadium.dto.UpdateStadiumDto;
+import com.minwonhaeso.esc.stadium.model.dto.CreateStadiumDto;
+import com.minwonhaeso.esc.stadium.model.dto.CreateStadiumItemDto;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumResponseDto;
+import com.minwonhaeso.esc.stadium.model.dto.UpdateStadiumDto;
 import com.minwonhaeso.esc.stadium.service.StadiumService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,14 +13,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/stadiums")
-public class StadiumController {
+public class StadiumManagerController {
     private final StadiumService stadiumService;
-
-    @GetMapping()
-    public ResponseEntity<?> getAllStadiums(Pageable pageable) {
-        Page<StadiumResponseDto> stadiums = stadiumService.getAllStadiums(pageable);
-        return ResponseEntity.ok().body(stadiums);
-    }
 
     @GetMapping("/manager")
     public ResponseEntity<?> getAllRegisteredStadiumsByManager(@PathVariable String memberId) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
@@ -1,0 +1,37 @@
+package com.minwonhaeso.esc.stadium.controller;
+
+import com.minwonhaeso.esc.stadium.model.dto.StadiumResponseDto;
+import com.minwonhaeso.esc.stadium.service.StadiumService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/stadiums")
+public class StadiumUserController {
+    private final StadiumService stadiumService;
+    private final Double DEFAULT_LAT = 37.5030;
+    private final Double DEFAULT_LNT = 127.0416;
+
+    @GetMapping()
+    public ResponseEntity<?> getAllStadiums(Pageable pageable) {
+        Page<StadiumResponseDto> stadiums = stadiumService.getAllStadiums(pageable);
+        return ResponseEntity.ok().body(stadiums);
+    }
+
+    @GetMapping("/near-loc")
+    public ResponseEntity<?> getAllStadiumsNearLocation(
+            @RequestParam Map<String, String> params, Pageable pageable) {
+        Double lnt = Double.valueOf(params.getOrDefault("lnt", String.valueOf(DEFAULT_LNT)));
+        Double lat = Double.valueOf(params.getOrDefault("lat", String.valueOf(DEFAULT_LAT)));
+
+        List<StadiumResponseDto> stadiums = stadiumService.getAllStadiumsNearLocation(lnt, lat, pageable);
+        return ResponseEntity.ok().body(stadiums);
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumDto.java
@@ -1,9 +1,10 @@
-package com.minwonhaeso.esc.stadium.dto;
+package com.minwonhaeso.esc.stadium.model.dto;
 
-import com.minwonhaeso.esc.stadium.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import lombok.*;
 
 import java.sql.Time;
+import java.util.ArrayList;
 import java.util.List;
 
 public class CreateStadiumDto {
@@ -12,7 +13,6 @@ public class CreateStadiumDto {
     @AllArgsConstructor
     @Builder
     public static class Request {
-        private List<String> imgs;
         private String name;
         private String phone;
         private String address;
@@ -20,10 +20,17 @@ public class CreateStadiumDto {
         private Double lnt;
         private Integer weekdayPricePerHalfHour;
         private Integer holidayPricePerHalfHour;
-        private List<String> tags;
         private Time openTime;
         private Time closeTime;
-        private List<CreateStadiumItemDto.Request> items;
+
+        @Builder.Default
+        private List<String> imgs = new ArrayList<>();
+
+        @Builder.Default
+        private List<String> tags = new ArrayList<>();
+
+        @Builder.Default
+        private List<CreateStadiumItemDto.Request> items = new ArrayList<>();
     }
 
     @Getter

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumItemDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumItemDto.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.dto;
+package com.minwonhaeso.esc.stadium.model.dto;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
@@ -1,7 +1,7 @@
-package com.minwonhaeso.esc.stadium.dto;
+package com.minwonhaeso.esc.stadium.model.dto;
 
-import com.minwonhaeso.esc.stadium.entity.Stadium;
-import com.minwonhaeso.esc.stadium.entity.StadiumImg;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumImg;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/UpdateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/UpdateStadiumDto.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.dto;
+package com.minwonhaeso.esc.stadium.model.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -1,7 +1,7 @@
-package com.minwonhaeso.esc.stadium.entity;
+package com.minwonhaeso.esc.stadium.model.entity;
 
-import com.minwonhaeso.esc.stadium.dto.CreateStadiumDto;
-import com.minwonhaeso.esc.stadium.dto.UpdateStadiumDto;
+import com.minwonhaeso.esc.stadium.model.dto.CreateStadiumDto;
+import com.minwonhaeso.esc.stadium.model.dto.UpdateStadiumDto;
 import com.sun.istack.NotNull;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -19,12 +19,13 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "stadium")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Stadium {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "stadium_id", nullable = false)
+    @Column(name = "id", nullable = false)
     private Long id;
 
     @NotNull
@@ -77,17 +78,17 @@ public class Stadium {
 //    @Column(name = "likes")
 //    private List<Like> likes;
 
+    @Builder.Default
     @OneToMany(mappedBy = "stadium")
-    @Column(name = "rental_items")
-    private List<StadiumItem> rentalStadiumItems;
+    private List<StadiumItem> rentalStadiumItems = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "stadium")
     private List<StadiumImg> imgs = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "stadium")
-    @Column(name = "tags")
-    private List<StadiumTag> tags;
+    private List<StadiumTag> tags = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "stadium")
 //    @Column(name = "reviews")

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumImg.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumImg.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.entity;
+package com.minwonhaeso.esc.stadium.model.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -14,11 +14,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "stadium_img")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class StadiumImg implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
@@ -1,7 +1,7 @@
-package com.minwonhaeso.esc.stadium.entity;
+package com.minwonhaeso.esc.stadium.model.entity;
 
-import com.minwonhaeso.esc.stadium.dto.CreateStadiumItemDto;
-import com.minwonhaeso.esc.stadium.type.StadiumItemStatus;
+import com.minwonhaeso.esc.stadium.model.dto.CreateStadiumItemDto;
+import com.minwonhaeso.esc.stadium.model.type.StadiumItemStatus;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-import static com.minwonhaeso.esc.stadium.type.StadiumItemStatus.AVAILABLE;
+import static com.minwonhaeso.esc.stadium.model.type.StadiumItemStatus.AVAILABLE;
 import static javax.persistence.EnumType.STRING;
 
 @Getter
@@ -18,12 +18,13 @@ import static javax.persistence.EnumType.STRING;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "stadium_item")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class StadiumItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "item_id")
+    @Column(name = "id")
     private Long id;
 
     @Column(name = "name", nullable = false)
@@ -33,7 +34,7 @@ public class StadiumItem {
     @JoinColumn(name = "stadium_id")
     private Stadium stadium;
 
-    @Column(name = "img_url")
+    @Column(name = "img_url", length = 1000)
     private String imgUrl;
 
     @Column(name = "price", nullable = false)

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.entity;
+package com.minwonhaeso.esc.stadium.model.entity;
 
 
 import lombok.*;
@@ -14,17 +14,20 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "stadium_tag")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class StadiumTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @ManyToOne
     @JoinColumn(name = "stadium_id")
     private Stadium stadium;
 
+    @Column(name = "name")
     private String name;
 
     @CreatedDate

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/type/StadiumItemStatus.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/type/StadiumItemStatus.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.type;
+package com.minwonhaeso.esc.stadium.model.type;
 
 public enum StadiumItemStatus {
     AVAILABLE, UNAVAILABLE

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumImgRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumImgRepository.java
@@ -1,7 +1,7 @@
 package com.minwonhaeso.esc.stadium.repository;
 
-import com.minwonhaeso.esc.stadium.entity.Stadium;
-import com.minwonhaeso.esc.stadium.entity.StadiumImg;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
@@ -1,6 +1,6 @@
 package com.minwonhaeso.esc.stadium.repository;
 
-import com.minwonhaeso.esc.stadium.entity.StadiumItem;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StadiumItemRepository extends JpaRepository<StadiumItem, Long> {

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
@@ -1,13 +1,19 @@
 package com.minwonhaeso.esc.stadium.repository;
 
-import com.minwonhaeso.esc.stadium.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
+
     @Override
     Page<Stadium> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepositorySupport.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepositorySupport.java
@@ -1,0 +1,33 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.minwonhaeso.esc.stadium.model.entity.QStadium.stadium;
+
+@Repository
+public class StadiumRepositorySupport extends QuerydslRepositorySupport {
+    private final JPAQueryFactory queryFactory;
+
+    public StadiumRepositorySupport(JPAQueryFactory queryFactory) {
+        super(Stadium.class);
+        this.queryFactory = queryFactory;
+    }
+
+    public List<Stadium> getAllStadiumsNearLocation(Double lnt, Double lat, Pageable pageable) {
+        return queryFactory
+                .selectFrom(stadium)
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .orderBy(Expressions.stringTemplate("ST_Distance_Sphere({0}, {1})",
+                        Expressions.stringTemplate("POINT({0}, {1})", lnt, lat),
+                        Expressions.stringTemplate("POINT({0}, {1})", stadium.lnt, stadium.lat)
+                ).asc()).fetch();
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumTagRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumTagRepository.java
@@ -1,6 +1,6 @@
 package com.minwonhaeso.esc.stadium.repository;
 
-import com.minwonhaeso.esc.stadium.entity.StadiumTag;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StadiumTagRepository extends JpaRepository<StadiumTag, Long> {

--- a/src/main/java/com/minwonhaeso/esc/stadium/util/LocationUtils.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/util/LocationUtils.java
@@ -1,0 +1,31 @@
+package com.minwonhaeso.esc.stadium.util;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class LocationUtils {
+    @Data
+    @Builder
+    public static class Location {
+        private Double lat;
+        private Double lnt;
+
+        public Double getDistance(Double toLat, Double toLnt) {
+            double theta = toLnt - this.lnt;
+            double dist = Math.sin(deg2rad(toLat)) * Math.sin(deg2rad(this.lat))
+                    + Math.cos(deg2rad(toLat)) * Math.cos(deg2rad(this.lat)) * Math.cos(deg2rad(theta));
+            dist = rad2deg(Math.acos(dist)) * 111.189557;
+            return Math.round(dist * 10000) / 10000.0;
+        }
+
+        // This function converts decimal degrees to radians
+        private Double deg2rad(Double deg) {
+            return (deg * Math.PI / 180.0);
+        }
+
+        // This function converts radians to decimal degrees
+        private Double rad2deg(Double rad) {
+            return (rad * 180 / Math.PI);
+        }
+    }
+}


### PR DESCRIPTION
### Background
---
- 추가적으로 소아님이 구성하신 패키지 경로가 더 깔끔하다고 생각돼서 
저도 model 패키지 안에 entity, dto, type 패키지를 넣어놓았습니다! 👍👍

### Change
---
- Querydsl 관련 의존성 추가했습니다!
- 체육관 등록시에 body에 이미지, 태그, 아이템 등에 대한 정보가 들어오지 않았을 때 
if로 한번 체크하는 부분을 일단 만들어 놓았는데 이부분 처리에서 좋은 방법이 있다면 알려주세요!!
- 위도와 경도 기반으로 가까운 체육관을 조회하는 것을 Querydsl의 Expressions.stringTemplate 이용하여 
MariaDB 혹은 MySQL에 있는  내장 함수를 직접 사용하여 쿼리를 날리는 방법으로 추가했습니다! 
관련 자료는 아래 같이 첨부하겠습니다!

### Test
---
- 필수요소가 아닌 이미지, 태그, 아이템 정보가 들어오지 않았을 때 http 메서드 테스트 진행했을 때 문제가 없었습니다! 
- 제 위치의 위도 경도를 입력했을 때 가까운 지역의 체육관부터 조회되는 것도 http 메서드 테스트를 진행했습니다. 다만, validation은 필요한 것 같아서 추후에 추가하도록 하겠습니다!

### Analytics
---
- StadiumUserController단에 추가한 가까운 체육관 조회 메서드 안에서 
@RequestParam 쿼리 파라미터로 위도 경도 값을 받아오는 과정에서 
Double로 변환하는데 살짝 부족해 보여서 이부분은 추가로 찾아본 뒤에 변경해보도록 하겠습니다!

### Discuss
---
- Querydsl을 사용하기 위한 StadiumRepositorySupport 클래스
- 체육관 등록시에 바뀐 로직 
- 중점적으로 리뷰해주시면 너무 감사드리겠습니다!!

### 참고 자료
[ST_Distance_Sphere 함수](https://velog.io/@hyunho058/Querydsl-SQL-Function)
[Querydsl](https://jojoldu.tistory.com/372)