### PR TITLE
Feat - OAuth2 JWT 토큰 발급 로직 변경

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -28,7 +28,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${test.url}")
     private String basicUrl;
 
-    private final static String REFRESH_TOKEN = "refresh_token";
+    @Value("${spring.jwt.refresh-token.cookie}")
+    private String refreshTokenForCookie;
 
     private final JwtTokenUtil jwtTokenUtil;
 
@@ -53,7 +54,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(memberEmail);
 
         int cookieMaxAge = (int) (REFRESH_TOKEN_EXPIRATION_TIME.getValue() / 60);
-        CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken.getRefreshToken(), cookieMaxAge);
+        CookieUtil.addCookie(response, refreshTokenForCookie, refreshToken.getRefreshToken(), cookieMaxAge);
 
         String targetUrl = makeRedirectUrl(token);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -5,6 +5,7 @@ import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;
 import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+import com.minwonhaeso.esc.security.oauth2.util.CookieUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -18,12 +19,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static com.minwonhaeso.esc.security.auth.jwt.JwtExpirationEnums.REFRESH_TOKEN_EXPIRATION_TIME;
+
 @Slf4j
 @Component
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     @Value("${test.url}")
     private String basicUrl;
+
+    private final static String REFRESH_TOKEN = "refresh_token";
 
     private final JwtTokenUtil jwtTokenUtil;
 
@@ -44,16 +49,19 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("Generate Token");
 
         String memberEmail = memberInfo.getEmail();
-
         String token = jwtTokenUtil.generateAccessToken(memberEmail);
         RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(memberEmail);
+
+        int cookieMaxAge = (int) (REFRESH_TOKEN_EXPIRATION_TIME.getValue() / 60);
+        CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken.getRefreshToken(), cookieMaxAge);
 
         String targetUrl = makeRedirectUrl(token);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
     private String makeRedirectUrl(String token) {
-        return UriComponentsBuilder.fromUriString(basicUrl+token)
+        return UriComponentsBuilder.fromUriString(basicUrl)
+                .queryParam("token", token)
                 .build().toUriString();
     }
 

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/util/CookieUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/util/CookieUtil.java
@@ -1,0 +1,47 @@
+package com.minwonhaeso.esc.security.oauth2.util;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+public class CookieUtil {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Background
---
기존 OAuth2 JWT 발급 로직에서는 AccessToken만 전달하고, RefreshToken을 프론트 단으로 전달하는 부분이 빠져있었습니다.

Change
---
OAuth2 RefreshToken을 발급 후, 서버 측 Redis에서만 저장을 하도록 했었는데, 클라이언트도 토큰 발급 요청 시, RefreshToken 정보가 필요하기 때문에 JWT(AccessToken, RefreshToken) 모두 전달할 수 있도록 하였습니다.

Analatics
---
AccessToken의 경우, 소셜 로그인 인증이 완료된 후 백엔드 API에 접글할 수 있는 AccessToken을 쿼리스트링으로 프론트에서 받아 처리할 수 있도록 하였습니다.

RefreshToken 경우, successHandler를 통해 인증 성공 시, short-lived 쿠키에 저장하여 프론트 단에서 저장할 수 있도록 하였습니다. 쿠키 옵션을 지정하였습니다. (httponly 추가 및 secure 미정) -> 연동 작업 시 추가적으로 회의 후, 설정할 예정입니다!

Discuss
---
OAuth2 JWT 발급 부분에서 Refresh Token 처리 부분에 대해 코멘트 부탁드립니다! 

Reference
---
첨부해드린 레퍼런스 통해 프론트-백 JWT 로직 부분을 참고하였습니다!
https://prolog.techcourse.co.kr/studylogs/2272
