### PR TITLE
Feat - Stadium : Controller, Dto Swagger API 문서 코드 작성

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -5,6 +5,7 @@ import com.minwonhaeso.esc.stadium.model.dto.CreateStadiumItemDto;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumResponseDto;
 import com.minwonhaeso.esc.stadium.model.dto.UpdateStadiumDto;
 import com.minwonhaeso.esc.stadium.service.StadiumService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,12 +17,14 @@ import org.springframework.web.bind.annotation.*;
 public class StadiumManagerController {
     private final StadiumService stadiumService;
 
+    @ApiOperation(value = "등록 체육관 조회", notes = "사용자(매니저)가 등록한 체육관을 조회한다.")
     @GetMapping("/manager")
     public ResponseEntity<?> getAllRegisteredStadiumsByManager(@PathVariable String memberId) {
         // TODO: Member 도메인 작업 후 진행
         return null;
     }
 
+    @ApiOperation(value = "체육관 신규 등록", notes = "사용자(매니저)가 체육관을 새로 등록한다.")
     @PostMapping("/register")
     public ResponseEntity<?> createStadiumByManager(
             @RequestBody CreateStadiumDto.Request request
@@ -30,6 +33,7 @@ public class StadiumManagerController {
         return ResponseEntity.status(HttpStatus.CREATED).body(stadium);
     }
 
+    @ApiOperation(value = "체육관 정보 수정", notes = "사용자(매니저)가 등록한 체육관의 정보를 수정한다.")
     @PatchMapping("/{stadiumId}/info")
     public ResponseEntity<?> updateStadiumInfo(
             @PathVariable Long stadiumId,
@@ -39,6 +43,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().body(stadium);
     }
 
+    @ApiOperation(value = "체육관 이미지 추가", notes = "사용자(매니저)가 등록한 체육관의 이미지를 1장 추가한다.")
     @PostMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> addStadiumImgByManager(
             @PathVariable Long stadiumId,
@@ -48,6 +53,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "체육관 종목(태그) 추가", notes = "사용자(매니저)가 등록한 체육관의 종목을 1개 추가한다.")
     @PostMapping("/{stadiumId}/tags")
     public ResponseEntity<?> addStadiumTagByManager(
             @PathVariable Long stadiumId,
@@ -57,6 +63,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "체육관 대여 용품 추가", notes = "사용자(매니저)가 등록한 체육관의 대여 용품을 1개 추가한다.")
     @PostMapping("/{stadiumId}/items")
     public ResponseEntity<?> addStadiumItemByManager(
             @PathVariable Long stadiumId,
@@ -66,6 +73,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().body(item);
     }
 
+    @ApiOperation(value = "체육관 이미지 삭제", notes = "사용자(매니저)가 등록한 체육관의 이미지 1장을 삭제한다.")
     @DeleteMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> deleteStadiumImgByManager(
             @PathVariable Long stadiumId,
@@ -75,6 +83,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "체육관 종목(태그) 삭제", notes = "사용자(매니저)가 등록한 체육관의 종목 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/tags")
     public ResponseEntity<?> deleteStadiumTagByManager(
             @PathVariable Long stadiumId,
@@ -84,6 +93,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "체육관 대여 용품 삭제", notes = "사용자(매니저)가 등록한 체육관의 대여 용품 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/items")
     public ResponseEntity<?> deleteStadiumItemByManager(
             @PathVariable Long stadiumId,
@@ -92,6 +102,7 @@ public class StadiumManagerController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "체육관 삭제", notes = "사용자(매니저)가 등록한 체육관을 삭제한다.")
     @DeleteMapping("/{stadiumId}")
     public ResponseEntity<?> deleteStadiumByManager(@PathVariable Long stadiumId) {
         stadiumService.deleteStadium(stadiumId);

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
@@ -2,6 +2,10 @@ package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.stadium.model.dto.StadiumResponseDto;
 import com.minwonhaeso.esc.stadium.service.StadiumService;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,15 +23,17 @@ public class StadiumUserController {
     private final Double DEFAULT_LAT = 37.5030;
     private final Double DEFAULT_LNT = 127.0416;
 
+    @ApiOperation(value = "체육관 조회", notes = "사용자(일반)가 체육관을 조회한다.")
     @GetMapping()
     public ResponseEntity<?> getAllStadiums(Pageable pageable) {
         Page<StadiumResponseDto> stadiums = stadiumService.getAllStadiums(pageable);
         return ResponseEntity.ok().body(stadiums);
     }
 
+    @ApiOperation(value = "가까운 체육관 조회", notes = "사용자(일반)의 위도 경도를 기준으로 가까운 체육관을 조회한다.")
     @GetMapping("/near-loc")
     public ResponseEntity<?> getAllStadiumsNearLocation(
-            @RequestParam Map<String, String> params, Pageable pageable) {
+            @ApiParam(value = "위도, 경도") @RequestParam Map<String, String> params, Pageable pageable) {
         Double lnt = Double.valueOf(params.getOrDefault("lnt", String.valueOf(DEFAULT_LNT)));
         Double lat = Double.valueOf(params.getOrDefault("lat", String.valueOf(DEFAULT_LAT)));
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumDto.java
@@ -1,7 +1,12 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
-import lombok.*;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.sql.Time;
 import java.util.ArrayList;
@@ -12,6 +17,7 @@ public class CreateStadiumDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @ApiModel(value = "체육관 생성 Request Body")
     public static class Request {
         private String name;
         private String phone;
@@ -20,7 +26,11 @@ public class CreateStadiumDto {
         private Double lnt;
         private Integer weekdayPricePerHalfHour;
         private Integer holidayPricePerHalfHour;
+
+        @ApiModelProperty(value = "오픈 시간", example = "HH:MM:SS")
         private Time openTime;
+
+        @ApiModelProperty(value = "마감 시간", example = "HH:MM:SS")
         private Time closeTime;
 
         @Builder.Default
@@ -37,6 +47,7 @@ public class CreateStadiumDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @ApiModel(value = "체육관 생성 성공 Response Body")
     public static class Response {
 //        private List<StadiumResponseDto> stadiums;
 //
@@ -44,6 +55,7 @@ public class CreateStadiumDto {
 //            return stadiumList.stream().map(StadiumResponseDto::fromEntity)
 //                    .collect(Collectors.toList());
 //        }
+
         private StadiumResponseDto stadium;
 
         public static Response fromEntity(Stadium stadium) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumItemDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/CreateStadiumItemDto.java
@@ -1,10 +1,12 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
 public class CreateStadiumItemDto {
     @Data
+    @ApiModel(value = "체육관 대여 용품 추가 Request Body")
     public static class Request {
         private String name;
         private String imgUrl;
@@ -14,6 +16,7 @@ public class CreateStadiumItemDto {
 
     @Data
     @Builder
+    @ApiModel(value = "체육관 대여 용품 추가 성공 Response Body")
     public static class Response {
         private String name;
         private String imgUrl;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
@@ -2,11 +2,15 @@ package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumImg;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumTag;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Time;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,15 +18,35 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ApiModel(value = "체육관 상세 정보")
 public class StadiumResponseDto {
+    @ApiModelProperty(value = "체육관 ID", example = "1")
     private Long id;
+
+    @ApiModelProperty(value = "위도", example = "37.5")
     private Double lat;
+
+    @ApiModelProperty(value = "경도", example = "127")
     private Double lnt;
+
+    @ApiModelProperty(value = "주소", example = "경기도 수원시")
     private String address;
+
+    @ApiModelProperty(value = "평점", example = "4.5")
     private Double star_avg;
+
+    @ApiModelProperty(value = "찜하기 수", example = "8")
     private Integer likes;
-    private List<String> imgs;
+
+    @ApiModelProperty(value = "이미지", example = "['img_url1', 'img_url2', ...]")
+    private List<String> imgs; // TODO: 이미지주소 + public_id도 포함 필요
     private List<String> tags;
+
+    @ApiModelProperty(value = "오픈 시간", example = "HH:MM:SS")
+    private Time openTime;
+
+    @ApiModelProperty(value = "마감 시간", example = "HH:MM:SS")
+    private Time closeTime;
 
     public static StadiumResponseDto fromEntity(Stadium stadium) {
         return StadiumResponseDto.builder()
@@ -31,14 +55,12 @@ public class StadiumResponseDto {
                 .lnt(stadium.getLnt())
                 .address(stadium.getAddress())
                 .star_avg(stadium.getStarAvg())
+                .openTime(stadium.getOpenTime())
+                .closeTime(stadium.getCloseTime())
 //                // TODO: 찜하기 수 업데이트
 //                .likes(stadium.getLikes().size())
-//
-                .imgs(stadium.getImgs().stream().map(StadiumImg::getImgUrl)
-                        .collect(Collectors.toList()))
-//
-//                // TODO: 태그 데이터 문자 리스트로 업데이트
-//                .tags(stadium.getTags().stream().map(Tag::getName).collect(Collectors.toList()))
+                .imgs(stadium.getImgs().stream().map(StadiumImg::getImgUrl).collect(Collectors.toList()))
+                .tags(stadium.getTags().stream().map(StadiumTag::getName).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/UpdateStadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/UpdateStadiumDto.java
@@ -1,5 +1,6 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
+import io.swagger.annotations.ApiModel;
 import lombok.*;
 
 import java.sql.Time;
@@ -10,6 +11,7 @@ public class UpdateStadiumDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @ApiModel(value = "체육관 정보 수정 Request Body")
     public static class Request {
         private String name;
         private String phone;
@@ -23,26 +25,31 @@ public class UpdateStadiumDto {
     }
 
     @Data
+    @ApiModel(value = "체육관 이미지 추가 Request Body")
     public static class AddImgRequest {
         private String imgUrl;
     }
 
     @Data
+    @ApiModel(value = "체육관 이미지 삭제 Request Body")
     public static class DeleteImgRequest {
         private String imgUrl;
     }
 
     @Data
+    @ApiModel(value = "체육관 종목(태그) 추가 Request Body")
     public static class AddTagRequest {
         private String tagName;
     }
 
     @Data
+    @ApiModel(value = "체육관 종목(태그) 삭제 Request Body")
     public static class DeleteTagRequest {
         private String tagName;
     }
 
     @Data
+    @ApiModel(value = "체육관 아이템 삭제 Request Body")
     public static class DeleteItemRequest {
         private Long itemId;
     }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -49,6 +49,10 @@ public class Stadium {
     private String address;
 
     @NotNull
+    @Column(name = "detail_address", nullable = false)
+    private String detailAddress;
+
+    @NotNull
     @Column(name = "weekday_price_per_half_hour", nullable = false)
     private Integer weekdayPricePerHalfHour;
 


### PR DESCRIPTION
### Background
---
재원님이랑 체육관 CRUD 관련 일정 맞춘 후에 Swagger API 문서 작업 진행 중입니다.

### Change
---
- DTO와 Controller단 먼저 작성을 하고 재원님께서 리뷰해주신 것 바탕으로 API문서화 코드
 추가로 작성할 예정입니다.
- 사소한 부분이지만 StadiumTag 데이터가 StadiumResponseDto 부분에서 주석처리되어 null로 표기돼서 이부분 다시 주석 해제하고 코드 작성했습니다!

### Test
---
Time 타입의 openTime과 closeTime이 Swagger에서 지원하지 않는 것 같아서 이부분 빼고는 API 문서에 문제없이 다 잘 들어와있고 ngrok 이용해서 재원님과도 같이 한번 봤습니다

### Analatics
---
Response쪽도 자세하게 작성이 필요하지만 우선 검색 API를 구현한 뒤에 진행하겠습니다!

### Discuss
---
- Response쪽을 실패할 때 나오는 응답까지 자세하게 작성할 것인지 회의하면 좋을 것 같아요!
