### PR TITLE
Feat - Auth 부분적인 오류 수정 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
@@ -8,6 +8,7 @@ public class LoginDto {
 
     @Getter
     @Setter
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Request {

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -72,9 +72,12 @@ public class Member{
                 .email(signDto.getEmail())
                 .name(signDto.getName())
                 .password(signDto.getPassword())
+                .status(MemberStatus.ING)
                 .nickname(signDto.getNickname())
                 .imgUrl(signDto.getImage())
                 .type(signDto.getType())
+                .providerType(ProviderType.LOCAL)
+                .providerId(signDto.getEmail().split("@")[0])
                 .build();
         if(signDto.getType() == MemberType.ADMIN){
             member.role = MemberRole.ROLE_STADIUM;
@@ -83,8 +86,6 @@ public class Member{
         }
         return member;
     }
-    //    @OneToMany(mappedBy = "member")
-//    private List<Stadidum> stadiums;
 
     public Member(Claims claims) {
         this.memberId = Long.valueOf(claims.get("userId").toString());

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberStatus.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberStatus.java
@@ -1,5 +1,5 @@
 package com.minwonhaeso.esc.member.model.type;
 
 public enum MemberStatus {
-    ING, STOP, WITHDRAW
+    ING, STOP
 }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -67,7 +67,7 @@ public class MemberService {
         }
     }
 
-    public void deliverEmailAuthCode(String email) {
+    public String deliverEmailAuthCode(String email) {
         String uuid = authUtil.generateAuthNo();
         Long emailExpiredTime = 1000L * 60 * 60 * 2;
         MemberEmail memberEmail = MemberEmail.createEmailAuthKey(email, uuid, emailExpiredTime);
@@ -75,6 +75,7 @@ public class MemberService {
         String content = "<p>이메일 인증 코드 : " + uuid + "</p>";
         mailComponents.sendMail(email, subject, content);
         memberEmailRepository.save(memberEmail);
+        return memberEmail.getId();
     }
 
     public void emailAuthentication(String key) {
@@ -108,7 +109,6 @@ public class MemberService {
         }
     }
 
-    @Transactional(isolation = Isolation.SERIALIZABLE)
     public void logout(TokenDto tokenDto, String username) {
         String accessToken = resolveToken(tokenDto.getAccessToken());
         long remainMilliSeconds = jwtTokenUtil.getRemainMilliSeconds(accessToken);
@@ -154,7 +154,7 @@ public class MemberService {
         Member member = memberRepository.findByEmail(user.getUsername())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
         if (request.getNickname() != null) {
-            member.setName(request.getNickname());
+            member.setNickname(request.getNickname());
         } else if (request.getImgUrl() != null) {
             member.setImgUrl(request.getImgUrl());
         }
@@ -183,7 +183,7 @@ public class MemberService {
         return principal.getUsername();
     }
 
-    public void changePasswordMail(String email) {
+    public String changePasswordMail(String email) {
         String uuid = authUtil.generateAuthNo();
         Long emailExpiredTime = 1000L * 60 * 60 * 2;
         MemberEmail memberEmail = MemberEmail.createEmailAuthKey(email, uuid, emailExpiredTime);
@@ -191,6 +191,7 @@ public class MemberService {
         String content = "<p>비밀번호 변경 코드: "+ uuid+ "</p>";
         mailComponents.sendMail(email, subject, content);
         memberEmailRepository.save(memberEmail);
+        return uuid;
     }
 
     public void changePasswordMailAuth(String key) {

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -82,7 +82,7 @@ public class MemberService {
         MemberEmail memberEmail = memberEmailRepository.findById(key).orElseThrow(
                 () -> new AuthException(AuthErrorCode.EmailAuthTimeOut));
         memberEmailRepository.save(memberEmail);
-        if(!memberEmail.getId().equals(key)){
+        if (!memberEmail.getId().equals(key)) {
             throw new AuthException(AuthErrorCode.AuthKeyNotMatch);
         }
     }
@@ -169,7 +169,7 @@ public class MemberService {
         memberRepository.delete(member);
     }
 
-    private String resolveToken(String token) {
+    public String resolveToken(String token) {
         return token.substring(7);
     }
 
@@ -188,7 +188,7 @@ public class MemberService {
         Long emailExpiredTime = 1000L * 60 * 60 * 2;
         MemberEmail memberEmail = MemberEmail.createEmailAuthKey(email, uuid, emailExpiredTime);
         String subject = "[ESC] 비밀번호 변경 안내";
-        String content = "<p>비밀번호 변경 코드: "+ uuid+ "</p>";
+        String content = "<p>비밀번호 변경 코드: " + uuid + "</p>";
         mailComponents.sendMail(email, subject, content);
         memberEmailRepository.save(memberEmail);
         return uuid;
@@ -198,7 +198,7 @@ public class MemberService {
         MemberEmail memberEmail = memberEmailRepository.findById(key).orElseThrow(
                 () -> new AuthException(AuthErrorCode.EmailAuthTimeOut));
         memberEmailRepository.delete(memberEmail);
-        if(!memberEmail.getId().equals(key)){
+        if (!memberEmail.getId().equals(key)) {
             throw new AuthException(AuthErrorCode.AuthKeyNotMatch);
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/security/auth/AuthUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/AuthUtil.java
@@ -1,5 +1,9 @@
 package com.minwonhaeso.esc.security.auth;
 
+
+import org.springframework.stereotype.Component;
+
+@Component
 public class AuthUtil {
 
     public String generateAuthNo() {

--- a/src/main/java/com/minwonhaeso/esc/security/auth/AuthUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/AuthUtil.java
@@ -1,0 +1,10 @@
+package com.minwonhaeso.esc.security.auth;
+
+public class AuthUtil {
+
+    public String generateAuthNo() {
+        java.util.Random generator = new java.util.Random();
+        generator.setSeed(System.currentTimeMillis());
+        return String.valueOf(generator.nextInt(1000000) % 1000000);
+    }
+}

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
@@ -2,24 +2,14 @@ package com.minwonhaeso.esc.member.service;
 
 import com.minwonhaeso.esc.error.exception.AuthException;
 import com.minwonhaeso.esc.error.type.AuthErrorCode;
-import com.minwonhaeso.esc.member.model.dto.LoginDto;
 import com.minwonhaeso.esc.member.model.dto.SignDto;
-import com.minwonhaeso.esc.member.model.dto.TokenDto;
 import com.minwonhaeso.esc.member.model.entity.Member;
-import com.minwonhaeso.esc.member.model.entity.MemberEmail;
 import com.minwonhaeso.esc.member.model.type.MemberType;
-import com.minwonhaeso.esc.member.repository.MemberEmailRepository;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
-import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
-import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,48 +19,12 @@ class MemberServiceTest {
     private MemberService memberService;
     @Autowired
     private MemberRepository memberRepository;
-    @Autowired
-    private MemberEmailRepository memberEmailRepository;
-    @Autowired
-    private RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @Test
-    void emailDuplicateYn (){
+    @DisplayName("이메일 인증부터 회원가입까지의 스토리 Test")
+    void memberSignUpStory() {
         //given
         String email = "ESC@gmail.com";
-        //when
-        memberService.emailDuplicateYn(email);
-        //then
-        Optional<Member> member =  memberRepository.findByEmail(email);
-        assertTrue(member.isEmpty());
-    }
-    @Test
-    void deliverEmailAuthCode(){
-        //given
-        String email = "ESC@gmail.com";
-        //when
-        String key = memberService.deliverEmailAuthCode(email);
-
-        //then
-        Optional<MemberEmail> optional =  memberEmailRepository.findById(key);
-        assertTrue(optional.isPresent());
-    }
-
-    @Test
-    void emailAuthentication(){
-        //given
-        // 위 deliverEmailAuthCode 에서 받은 값을 사용.
-        String key = "614789";
-        //when
-        memberService.emailAuthentication(key);
-        Optional<MemberEmail> optional = memberEmailRepository.findById(key);
-        //then
-        assertTrue(optional.isPresent());
-    }
-
-    @Test
-    void signUser (){
-        //given
         SignDto.Request signDto = SignDto.Request.builder()
                 .email("ESC@gmail.com")
                 .name("ESC_TEST")
@@ -78,12 +32,15 @@ class MemberServiceTest {
                 .type(MemberType.ADMIN)
                 .nickname("ESC")
                 .image("/ESC/test/image.img")
-                .key("614789")
                 .build();
         //when
+        memberService.emailDuplicateYn(email);
+        String key = memberService.deliverEmailAuthCode(email);
+        memberService.emailAuthentication(key);
+        signDto.setKey(key);
         SignDto.Response response = memberService.signUser(signDto);
         //then
-        Member member = memberRepository.findByEmail(signDto.getEmail()).orElseThrow(()-> new AuthException(AuthErrorCode.EmailNotMatched));
+        Member member = memberRepository.findByEmail(signDto.getEmail()).orElseThrow(() -> new AuthException(AuthErrorCode.EmailNotMatched));
         assertEquals(member.getName(), response.getName());
     }
 }

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
@@ -1,0 +1,89 @@
+package com.minwonhaeso.esc.member.service;
+
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
+import com.minwonhaeso.esc.member.model.dto.LoginDto;
+import com.minwonhaeso.esc.member.model.dto.SignDto;
+import com.minwonhaeso.esc.member.model.dto.TokenDto;
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.model.entity.MemberEmail;
+import com.minwonhaeso.esc.member.model.type.MemberType;
+import com.minwonhaeso.esc.member.repository.MemberEmailRepository;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
+import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberServiceTest {
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberEmailRepository memberEmailRepository;
+    @Autowired
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @Test
+    void emailDuplicateYn (){
+        //given
+        String email = "ESC@gmail.com";
+        //when
+        memberService.emailDuplicateYn(email);
+        //then
+        Optional<Member> member =  memberRepository.findByEmail(email);
+        assertTrue(member.isEmpty());
+    }
+    @Test
+    void deliverEmailAuthCode(){
+        //given
+        String email = "ESC@gmail.com";
+        //when
+        String key = memberService.deliverEmailAuthCode(email);
+
+        //then
+        Optional<MemberEmail> optional =  memberEmailRepository.findById(key);
+        assertTrue(optional.isPresent());
+    }
+
+    @Test
+    void emailAuthentication(){
+        //given
+        // 위 deliverEmailAuthCode 에서 받은 값을 사용.
+        String key = "614789";
+        //when
+        memberService.emailAuthentication(key);
+        Optional<MemberEmail> optional = memberEmailRepository.findById(key);
+        //then
+        assertTrue(optional.isPresent());
+    }
+
+    @Test
+    void signUser (){
+        //given
+        SignDto.Request signDto = SignDto.Request.builder()
+                .email("ESC@gmail.com")
+                .name("ESC_TEST")
+                .password("1111")
+                .type(MemberType.ADMIN)
+                .nickname("ESC")
+                .image("/ESC/test/image.img")
+                .key("614789")
+                .build();
+        //when
+        SignDto.Response response = memberService.signUser(signDto);
+        //then
+        Member member = memberRepository.findByEmail(signDto.getEmail()).orElseThrow(()-> new AuthException(AuthErrorCode.EmailNotMatched));
+        assertEquals(member.getName(), response.getName());
+    }
+}

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
@@ -1,0 +1,132 @@
+package com.minwonhaeso.esc.member.service;
+
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
+import com.minwonhaeso.esc.member.model.dto.*;
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
+import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberServiceWithPrincipalTest {
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    //토큰이 필요한 테스트의 경우, 사전 세팅 메소드
+    private UserDetails setUserToContextByUsername(String username) {
+        CustomerMemberDetailsService customUserDetailsService = new CustomerMemberDetailsService(memberRepository);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
+        return userDetails;
+    }
+
+    @Test
+    void login() {
+        //given
+        LoginDto.Request request = LoginDto.Request
+                .builder()
+                .email("ESC@gmail.com")
+                .password("1111")
+                .build();
+        //when
+        LoginDto.Response response = memberService.login(request);
+        //then
+        Optional<RefreshToken> optional = refreshTokenRedisRepository.findById(request.getEmail());
+        assertEquals(response.getRefreshToken(), optional.get().getRefreshToken());
+    }
+
+    @Test
+    void reissue() {
+        //given
+        String email = "ESC@gmail.com";
+        //when
+        login();
+        setUserToContextByUsername(email);
+        RefreshToken before = refreshTokenRedisRepository.findById(email).orElseThrow(() -> new AuthException(AuthErrorCode.EmailNotMatched));
+        String refreshToken = "Bearer " + before.getRefreshToken();
+        TokenDto after = memberService.reissue(refreshToken);
+        //then
+        assertEquals(before.getRefreshToken(), after.getRefreshToken());
+    }
+
+    @Test
+    void info() {
+        //given
+        String email = "ESC@gmail.com";
+        //when
+        UserDetails userDetails = setUserToContextByUsername(email);
+        InfoDto.Response response = memberService.info(userDetails);
+        //then
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
+        assertEquals(response.getName(), member.getName());
+    }
+
+    @Test
+    void patchInfo() {
+        //given
+        String email = "ESC@gmail.com";
+        PatchInfo.Request request = PatchInfo.Request.builder()
+                .nickname("ESC 테스트 유저")
+                .build();
+
+        //when
+        UserDetails userDetails = setUserToContextByUsername(email);
+        memberService.patchInfo(userDetails,request);
+        //then
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
+        assertEquals(member.getNickname(), request.getNickname());
+    }
+    @Test
+    void passwordChange(){
+        //given
+        String email = "ESC@gmail.com";
+        setUserToContextByUsername(email);
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email(email)
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("1234")
+                .build();
+        //when
+        String uuid =  memberService.changePasswordMail(email);
+        memberService.changePasswordMailAuth(uuid);
+        memberService.changePassword(request);
+        //then
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.EmailNotMatched));
+        assertTrue(passwordEncoder.matches("1234",member.getPassword()));
+    }
+    @Test
+    void deleteMember(){
+        //given
+        String email = "ESC@gmail.com";
+        UserDetails userDetails= setUserToContextByUsername(email);
+        //when
+        memberService.deleteMember(userDetails);
+        //then
+        Optional<Member> optional = memberRepository.findByEmail(email);
+        assertTrue(optional.isEmpty());
+    }
+}


### PR DESCRIPTION
Background
---
이메일 인증 키를 생성하는 메소드가 memberService에 같이 들어있었다.
불필요한 Transaction이 걸려있었다.
Postman을 통한 실험은 성공했지만, test코드 작성은 안한 상태

Change
---
1. 이메일 인증 키를 생성하는 메소드를 AuthUtil파일로 분리.
2. deleteMember메소드의 불필요한 Transaction 삭제
3. TestCode 작성
   a.  Header에 토큰 정보가 필요한 경우 -> MemberServiceWithPrincipalTest
   b. 토큰 정보가 필요 없는 경우 -> MemberServiceTest

Analatics
---
TestCode작성에서 Header에 로그인 정보가 필요한 경우  아래 메소드로 setUp 후 Test를 진행했습니다.
앞으로의 테스트에도 필요할 것 같아 코드로 남겨놉니다.
```java
private UserDetails setUserToContextByUsername(String username) {
        CustomerMemberDetailsService customUserDetailsService = new CustomerMemberDetailsService(memberRepository);
        UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
        SecurityContext context = SecurityContextHolder.getContext();
        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities()));
        return userDetails;
    }
```

Discuss
---
reissue의 경우 위 메소드를 가지고 테스트해도 refreshTokenRepository에 토큰이 save되는 것이 아니라  조금 불완전한 Test코드 같습니다. 
이러한 부분을 해결하는 방법이 혹시 있다면 말씀 부탁드립니다.
Reference
---
아래 레퍼런스를 통해 테스트코드에서 사용자 정보를 가져와 사용하였고 좀 더 깔끔한 방법으로 WithSecurityContextFactory구현체를 이용하는 방법이 있지만, 해당 구현체를 implements할 수  없는 springboot 버전이기 때문에 지금과 같은 방식으로 해결했습니다.
https://velog.io/@smallcherry/Spring-Security%EA%B0%80-%EC%A0%81%EC%9A%A9%EB%90%9C-%EC%BD%94%EB%93%9C-%ED%85%8C%EC%8A%A4%ED%8A%B8%ED%95%98%EB%8A%94-%EB%B2%95
