### PR TITLE
Fix : Swagger + 프론트 통합 이슈 수정 #28 #29 #30 #31 #32

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/common/config/ElasticsearchConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/common/config/ElasticsearchConfig.java
@@ -14,7 +14,7 @@ public class ElasticsearchConfig extends AbstractElasticsearchConfiguration {
     @Value("${elasticsearch.url}")
     private String hostUrl;
 
-    @Value("${elasticsearch.clustername")
+    @Value("${elasticsearch.clusterName}")
     private String clusterName;
 
     @Override

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.minwonhaeso.esc.member.model.dto.SignDto;
 import com.minwonhaeso.esc.member.model.dto.TokenDto;
 import com.minwonhaeso.esc.member.service.MemberService;
 import com.minwonhaeso.esc.security.auth.jwt.JwtTokenUtil;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +22,7 @@ public class MemberController {
     /**
      * 회원가입
      **/
+    @ApiOperation(value = "회원 가입", notes = "입력한 정보로 회원가입한다.")
     @PostMapping("/signUp")
     public ResponseEntity<?> signUp(@RequestBody SignDto.Request signDto) {
         SignDto.Response response = memberService.signUser(signDto);
@@ -30,6 +32,7 @@ public class MemberController {
     /**
      * 회원가입 이메일 중복 검사
      **/
+    @ApiOperation(value = "이메일 중복 확인", notes = "입력 받은 이메일의 회원이 이미 존재하는지 확인한다.")
     @PostMapping("/email-dup")
     public ResponseEntity<?> emailDuplicated(@RequestBody Map<String, String> email) {
         memberService.emailDuplicateYn(email.get("email"));
@@ -39,6 +42,7 @@ public class MemberController {
     /**
      * 회원가입 이메일 인증 코드 전송
      **/
+    @ApiOperation(value = "이메일 인증 코드 전송", notes = "이메일로 회원가입을 위한 코드를 전송합니다.")
     @PostMapping("/email-auth")
     public ResponseEntity<?> deliverEmailAuthCode(@RequestBody Map<String, String> email) {
         memberService.deliverEmailAuthCode(email.get("email"));
@@ -49,6 +53,7 @@ public class MemberController {
     /**
      * 메일 인증
      **/
+    @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
     @PostMapping("/email-authentication")
     public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
         memberService.emailAuthentication(key);
@@ -58,6 +63,7 @@ public class MemberController {
     /**
      * 로그인
      **/
+    @ApiOperation(value = "로그인", notes = "일반 계정 혹은 판매자로 사용자가 로그인합니다.")
     @PostMapping("/auth/login")
     public ResponseEntity<?> login(@RequestBody LoginDto.Request loginDto) {
         LoginDto.Response response = memberService.login(loginDto);
@@ -67,6 +73,7 @@ public class MemberController {
     /**
      * 로그아웃
      **/
+    @ApiOperation(value = "로그아웃", notes = "사용자의 로그아웃")
     @PostMapping("/auth/logout")
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
                                     @RequestHeader("RefreshToken") String refreshToken) {
@@ -78,6 +85,7 @@ public class MemberController {
     /**
      * Token reissue
      **/
+    @ApiOperation(value = "토큰 재발급", notes = "유효기간이 지난 토큰을 재발급합니다.")
     @PostMapping("/auth/refresh-token")
     public ResponseEntity<?> reissue(@RequestHeader("RefreshToken") String refreshToken) {
         return ResponseEntity.ok(memberService.reissue(refreshToken));

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -23,7 +24,7 @@ public class MemberController {
      * 회원가입
      **/
     @ApiOperation(value = "회원 가입", notes = "입력한 정보로 회원가입한다.")
-    @PostMapping("/signUp")
+    @PostMapping("/signup")
     public ResponseEntity<?> signUp(@RequestBody SignDto.Request signDto) {
         SignDto.Response response = memberService.signUser(signDto);
         return ResponseEntity.ok(response);
@@ -35,8 +36,9 @@ public class MemberController {
     @ApiOperation(value = "이메일 중복 확인", notes = "입력 받은 이메일의 회원이 이미 존재하는지 확인한다.")
     @PostMapping("/email-dup")
     public ResponseEntity<?> emailDuplicated(@RequestBody Map<String, String> email) {
-        memberService.emailDuplicateYn(email.get("email"));
-        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+
+
+        return ResponseEntity.ok(memberService.emailDuplicateYn(email.get("email")));
     }
 
     /**
@@ -46,18 +48,18 @@ public class MemberController {
     @PostMapping("/email-auth")
     public ResponseEntity<?> deliverEmailAuthCode(@RequestBody Map<String, String> email) {
         memberService.deliverEmailAuthCode(email.get("email"));
-
-        return ResponseEntity.ok("이메일 인증 코드를 전송했습니다.");
+        Map<String, String> result = new HashMap<>();
+        result.put("message", "이메일 인증 코드를 전송했습니다.");
+        return ResponseEntity.ok(result);
     }
 
     /**
      * 메일 인증
      **/
     @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
-    @PostMapping("/email-authentication")
+    @GetMapping("/email-authentication")
     public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
-        memberService.emailAuthentication(key);
-        return ResponseEntity.ok("메일 인증이 완료되었습니다.");
+        return ResponseEntity.ok(memberService.emailAuthentication(key));
     }
 
     /**
@@ -78,8 +80,7 @@ public class MemberController {
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
                                     @RequestHeader("RefreshToken") String refreshToken) {
         String username = jwtTokenUtil.getUsername(resolveToken(accessToken));
-        memberService.logout(TokenDto.of(accessToken, refreshToken), username);
-        return ResponseEntity.ok("로그아웃");
+        return ResponseEntity.ok(memberService.logout(TokenDto.of(accessToken, refreshToken), username));
     }
 
     /**
@@ -90,7 +91,7 @@ public class MemberController {
     public ResponseEntity<?> reissue(@RequestHeader("RefreshToken") String refreshToken) {
         return ResponseEntity.ok(memberService.reissue(refreshToken));
     }
-    
+
     /**
      * Bearer 부분 빼는 method
      **/

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -36,9 +36,8 @@ public class MemberController {
     @ApiOperation(value = "이메일 중복 확인", notes = "입력 받은 이메일의 회원이 이미 존재하는지 확인한다.")
     @PostMapping("/email-dup")
     public ResponseEntity<?> emailDuplicated(@RequestBody Map<String, String> email) {
-
-
-        return ResponseEntity.ok(memberService.emailDuplicateYn(email.get("email")));
+        Map<String, String> result = memberService.emailDuplicateYn(email.get("email"));
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -48,8 +47,7 @@ public class MemberController {
     @PostMapping("/email-auth")
     public ResponseEntity<?> deliverEmailAuthCode(@RequestBody Map<String, String> email) {
         memberService.deliverEmailAuthCode(email.get("email"));
-        Map<String, String> result = new HashMap<>();
-        result.put("message", "이메일 인증 코드를 전송했습니다.");
+        Map<String, String> result = memberService.successMessage("이메일 인증 코드를 전송했습니다.");
         return ResponseEntity.ok(result);
     }
 
@@ -59,7 +57,8 @@ public class MemberController {
     @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
     @GetMapping("/email-authentication")
     public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
-        return ResponseEntity.ok(memberService.emailAuthentication(key));
+        Map<String, String> result = memberService.emailAuthentication(key);
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -80,7 +79,8 @@ public class MemberController {
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
                                     @RequestHeader("RefreshToken") String refreshToken) {
         String username = jwtTokenUtil.getUsername(resolveToken(accessToken));
-        return ResponseEntity.ok(memberService.logout(TokenDto.of(accessToken, refreshToken), username));
+        Map<String, String> result = memberService.logout(TokenDto.of(accessToken, refreshToken), username);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -43,8 +44,8 @@ public class MemberProfileController {
     @ApiOperation(value = "회원 탈퇴", notes = "해당 서비스를 탈퇴합니다.")
     @DeleteMapping("/info")
     public ResponseEntity<?> delete(@AuthenticationPrincipal UserDetails userDetails) {
-        memberService.deleteMember(userDetails);
-        return ResponseEntity.ok("탈퇴에 성공했습니다.");
+
+        return ResponseEntity.ok(memberService.deleteMember(userDetails));
     }
 
     /**
@@ -53,9 +54,10 @@ public class MemberProfileController {
     @ApiOperation(value = "비밀번호 변경 이메일 전송", notes = "인증 코드와 함께 본인확인을 위한 이메일을 전송한다.")
     @PostMapping("/password/send-mail")
     public ResponseEntity<?> changePasswordMail(@RequestBody Map<String, String> body) {
-        String email = body.get("email");
-        memberService.changePasswordMail(email);
-        return ResponseEntity.ok("메일이 발송되었습니다.");
+        memberService.changePasswordMail(body.get("email"));
+        Map<String, String> result = new HashMap<>();
+        result.put("message", "메일이 발송되었습니다.");
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -64,8 +66,7 @@ public class MemberProfileController {
     @ApiOperation(value = "인증코드 확인(비밀번호 변경)", notes = "비밀번호 변경을 위한 메일 인증 코드 일치 여부를 확인합니다.")
     @GetMapping("/password")
     public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key) {
-        memberService.changePasswordMailAuth(key);
-        return ResponseEntity.ok("메일 인증이 완료되었습니다.");
+        return ResponseEntity.ok(memberService.changePasswordMailAuth(key));
     }
 
     /**
@@ -74,7 +75,6 @@ public class MemberProfileController {
     @ApiOperation(value = "비밀번호 변경", notes = "이전 비밀번호가 일치하는지 확인하고, 새로운 비밀번호로 변경합니다.")
     @PostMapping("/password")
     public ResponseEntity<?> changePassword(@RequestBody CPasswordDto.Request request) {
-        memberService.changePassword(request);
-        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+        return ResponseEntity.ok(memberService.changePassword(request));
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -44,8 +44,8 @@ public class MemberProfileController {
     @ApiOperation(value = "회원 탈퇴", notes = "해당 서비스를 탈퇴합니다.")
     @DeleteMapping("/info")
     public ResponseEntity<?> delete(@AuthenticationPrincipal UserDetails userDetails) {
-
-        return ResponseEntity.ok(memberService.deleteMember(userDetails));
+        Map<String, String> result = memberService.deleteMember(userDetails);
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -55,8 +55,7 @@ public class MemberProfileController {
     @PostMapping("/password/send-mail")
     public ResponseEntity<?> changePasswordMail(@RequestBody Map<String, String> body) {
         memberService.changePasswordMail(body.get("email"));
-        Map<String, String> result = new HashMap<>();
-        result.put("message", "메일이 발송되었습니다.");
+        Map<String, String> result = memberService.successMessage("메일이 발송되었습니다.");
         return ResponseEntity.ok(result);
     }
 
@@ -66,7 +65,8 @@ public class MemberProfileController {
     @ApiOperation(value = "인증코드 확인(비밀번호 변경)", notes = "비밀번호 변경을 위한 메일 인증 코드 일치 여부를 확인합니다.")
     @GetMapping("/password")
     public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key) {
-        return ResponseEntity.ok(memberService.changePasswordMailAuth(key));
+        Map<String, String> result = memberService.changePasswordMailAuth(key);
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -75,6 +75,7 @@ public class MemberProfileController {
     @ApiOperation(value = "비밀번호 변경", notes = "이전 비밀번호가 일치하는지 확인하고, 새로운 비밀번호로 변경합니다.")
     @PostMapping("/password")
     public ResponseEntity<?> changePassword(@RequestBody CPasswordDto.Request request) {
-        return ResponseEntity.ok(memberService.changePassword(request));
+        Map<String, String> result = memberService.changePassword(request);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.member.controller;
 import com.minwonhaeso.esc.member.model.dto.CPasswordDto;
 import com.minwonhaeso.esc.member.model.dto.PatchInfo;
 import com.minwonhaeso.esc.member.service.MemberService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +21,7 @@ public class MemberProfileController {
     /**
      * 회원 상세 정보 요청
      **/
+    @ApiOperation(value = "회원 상세 정보", notes = "회원 정보 페이지에 필요한 상세 정보를 보여줍니다.")
     @PostMapping("/info")
     public ResponseEntity<?> info(@AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(memberService.info(userDetails));
@@ -28,6 +30,7 @@ public class MemberProfileController {
     /**
      * 회원 수정
      **/
+    @ApiOperation(value = "회원 정보 수정", notes = "프로필 사진과 닉네임 정보를 수정합니다.")
     @PatchMapping("/info")
     public ResponseEntity<?> patchInfo(@AuthenticationPrincipal UserDetails userDetails,
                                        @RequestBody PatchInfo.Request request) {
@@ -37,6 +40,7 @@ public class MemberProfileController {
     /**
      * 회원 탈퇴
      **/
+    @ApiOperation(value = "회원 탈퇴", notes = "해당 서비스를 탈퇴합니다.")
     @DeleteMapping("/info")
     public ResponseEntity<?> delete(@AuthenticationPrincipal UserDetails userDetails) {
         memberService.deleteMember(userDetails);
@@ -46,6 +50,7 @@ public class MemberProfileController {
     /**
      * 비밀번호 변경 메일 전송
      **/
+    @ApiOperation(value = "비밀번호 변경 이메일 전송", notes = "인증 코드와 함께 본인확인을 위한 이메일을 전송한다.")
     @PostMapping("/password/send-mail")
     public ResponseEntity<?> changePasswordMail(@RequestBody Map<String, String> body) {
         String email = body.get("email");
@@ -56,6 +61,7 @@ public class MemberProfileController {
     /**
      * 비밀번호 변경 메일 인증코드 확인
      **/
+    @ApiOperation(value = "인증코드 확인(비밀번호 변경)", notes = "비밀번호 변경을 위한 메일 인증 코드 일치 여부를 확인합니다.")
     @GetMapping("/password")
     public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key) {
         memberService.changePasswordMailAuth(key);
@@ -65,6 +71,7 @@ public class MemberProfileController {
     /**
      * 비밀번호 변경
      **/
+    @ApiOperation(value = "비밀번호 변경", notes = "이전 비밀번호가 일치하는지 확인하고, 새로운 비밀번호로 변경합니다.")
     @PostMapping("/password")
     public ResponseEntity<?> changePassword(@RequestBody CPasswordDto.Request request) {
         memberService.changePassword(request);

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
@@ -11,7 +11,7 @@ public class SignDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Request {
-        private MemberType type;
+        private String type;
         private String email;
         private String name;
         private String password;
@@ -19,11 +19,12 @@ public class SignDto {
         private String image;
         private String key;
     }
+
     @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class Response{
+    public static class Response {
         private String name;
         private String image;
     }

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -74,7 +74,7 @@ public class Member {
             member.setType(MemberType.USER);
             member.setRole(MemberRole.ROLE_USER);
         } else {
-            member.setType(MemberType.STADIUM);
+            member.setType(MemberType.MANAGER);
             member.setRole(MemberRole.ROLE_STADIUM);
         }
         return member;

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -19,7 +19,7 @@ import javax.persistence.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Member{
+public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
@@ -59,24 +59,23 @@ public class Member{
     private String providerId;
 
 
-
-
     public static Member of(SignDto.Request signDto) {
-        Member member =  Member.builder()
+        Member member = Member.builder()
                 .email(signDto.getEmail())
                 .name(signDto.getName())
                 .password(signDto.getPassword())
                 .status(MemberStatus.ING)
                 .nickname(signDto.getNickname())
                 .imgUrl(signDto.getImage())
-                .type(signDto.getType())
                 .providerType(ProviderType.LOCAL)
                 .providerId(signDto.getEmail().split("@")[0])
                 .build();
-        if(signDto.getType() == MemberType.ADMIN){
-            member.role = MemberRole.ROLE_STADIUM;
-        }else{
-            member.role = MemberRole.ROLE_USER;
+        if (signDto.getType().equals(MemberType.USER.name())) {
+            member.setType(MemberType.USER);
+            member.setRole(MemberRole.ROLE_USER);
+        } else {
+            member.setType(MemberType.STADIUM);
+            member.setRole(MemberRole.ROLE_STADIUM);
         }
         return member;
     }

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
@@ -1,5 +1,5 @@
 package com.minwonhaeso.esc.member.model.type;
 
 public enum MemberType {
-    USER, STADIUM
+    USER, MANAGER
 }

--- a/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/type/MemberType.java
@@ -1,5 +1,5 @@
 package com.minwonhaeso.esc.member.model.type;
 
 public enum MemberType {
-    USER,ADMIN
+    USER, STADIUM
 }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -217,7 +217,7 @@ public class MemberService {
         return successMessage("비밀번호가 성공적으로 변경되었습니다.");
     }
 
-    private Map<String, String> successMessage(String message) {
+    public Map<String, String> successMessage(String message) {
         Map<String, String> result = new HashMap<>();
         result.put("message", message);
         return result;


### PR DESCRIPTION
### Background
---
ElasticConfig clustername 받아오는 Value 어노테이션에서 중괄호가 안 닫혀있었다.
회원가입할 때 request에서 type을 MemberType(enum)값으로 받고 있었다.
Auth 관련 Controller에서 성공 메시지를 Response.ok("String")형식으로 작성 됐었다.

### Change
---
ClusterConfig @Value("${elasticsearch.clusterName") 부분 중괄호 추가 
Controller 반환을 String에서 Map형태로 변경
SignDto.Request type의 형태를 MemberType -> String으로 변경
MemberService Request에서 nickname이 아닌 name을 받는 부분 수정
MemberType ADMIN -> STADIUM으로 수정 
인증키 확인하는 요청 Post -> Get
회원가입 요청 url signUp -> signup

### Analytics
---
postman과 TestCode를 통해서 변경한 부분들이 잘 작동하는지 확인했습니다.

### Discuss
---
추가로 제가 이슈에 대해서 잘못 이해한 부분이 있다면 알려주세요!!
