### PR TITLE
Feat : 체육관 CRUD 권한 설정 및 체육관 검색 CRUD 수정

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum StadiumErrorCode {
-    StadiumNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 정보가 존재하지 않습니다.");
+    StadiumNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 정보가 존재하지 않습니다."),
+    UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
 
     private final HttpStatus statusCode;
     private final String errorMessage;

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -46,30 +46,36 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 정보 수정", notes = "사용자(매니저)가 등록한 체육관의 정보를 수정한다.")
     @PatchMapping("/{stadiumId}/info")
     public ResponseEntity<?> updateStadiumInfo(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
-            StadiumDto.UpdateStadiumRequest request
+            @RequestBody StadiumDto.UpdateStadiumRequest request
     ) {
-        StadiumResponseDto stadium = stadiumService.updateStadiumInfo(stadiumId, request);
+        Member member = principalDetails.getMember();
+        StadiumResponseDto stadium = stadiumService.updateStadiumInfo(member, stadiumId, request);
         return ResponseEntity.ok().body(stadium);
     }
 
     @ApiOperation(value = "체육관 이미지 추가", notes = "사용자(매니저)가 등록한 체육관의 이미지를 1장 추가한다.")
     @PostMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> addStadiumImgByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumImgDto.AddImgRequest request
     ) {
-        StadiumImgDto.CreateImgResponse img = stadiumService.addStadiumImg(stadiumId, request.getImgUrl());
+        Member member = principalDetails.getMember();
+        StadiumImgDto.CreateImgResponse img = stadiumService.addStadiumImg(member, stadiumId, request.getImgUrl());
         return ResponseEntity.ok().body(img);
     }
 
     @ApiOperation(value = "체육관 종목(태그) 추가", notes = "사용자(매니저)가 등록한 체육관의 종목을 1개 추가한다.")
     @PostMapping("/{stadiumId}/tags")
     public ResponseEntity<?> addStadiumTagByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumTagDto.AddTagRequest request
     ) {
-        StadiumTagDto.AddTagResponse tag = stadiumService.addStadiumTag(stadiumId, request.getTagName());
+        Member member = principalDetails.getMember();
+        StadiumTagDto.AddTagResponse tag = stadiumService.addStadiumTag(member, stadiumId, request.getTagName());
         return ResponseEntity.ok().body(tag);
     }
 
@@ -86,36 +92,45 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 이미지 삭제", notes = "사용자(매니저)가 등록한 체육관의 이미지 1장을 삭제한다.")
     @DeleteMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> deleteStadiumImgByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumImgDto.DeleteImgRequest request
     ) {
-        stadiumService.deleteStadiumImg(stadiumId, request.getImgUrl());
+        Member member = principalDetails.getMember();
+        stadiumService.deleteStadiumImg(member, stadiumId, request.getImgUrl());
         return ResponseEntity.ok().build();
     }
 
     @ApiOperation(value = "체육관 종목(태그) 삭제", notes = "사용자(매니저)가 등록한 체육관의 종목 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/tags")
     public ResponseEntity<?> deleteStadiumTagByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumTagDto.DeleteTagRequest request
     ) {
-        stadiumService.deleteStadiumTag(stadiumId, request.getTagName());
+        Member member = principalDetails.getMember();
+        stadiumService.deleteStadiumTag(member, stadiumId, request.getTagName());
         return ResponseEntity.ok().build();
     }
 
     @ApiOperation(value = "체육관 대여 용품 삭제", notes = "사용자(매니저)가 등록한 체육관의 대여 용품 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/items")
     public ResponseEntity<?> deleteStadiumItemByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumItemDto.DeleteItemRequest request) {
-        stadiumService.deleteStadiumItem(stadiumId, request);
+        Member member = principalDetails.getMember();
+        stadiumService.deleteStadiumItem(member, stadiumId, request);
         return ResponseEntity.ok().build();
     }
 
     @ApiOperation(value = "체육관 삭제", notes = "사용자(매니저)가 등록한 체육관을 삭제한다.")
-    @DeleteMapping("/{stadiumId}")
-    public ResponseEntity<?> deleteStadiumByManager(@PathVariable Long stadiumId) {
-        stadiumService.deleteStadium(stadiumId);
+    @DeleteMapping("/{stadiumId}/info")
+    public ResponseEntity<?> deleteStadiumByManager(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long stadiumId) {
+        Member member = principalDetails.getMember();
+        stadiumService.deleteStadium(member, stadiumId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumUserController.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.stadium.model.dto.SearchStadiumDto;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumInfoResponseDto;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumResponseDto;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumDocument;
 import com.minwonhaeso.esc.stadium.service.StadiumSearchService;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,6 +35,17 @@ public class StadiumUserController {
     public ResponseEntity<?> getAllStadiums(Pageable pageable) {
         Page<StadiumResponseDto> stadiums = stadiumService.getAllStadiums(pageable);
         return ResponseEntity.ok().body(stadiums);
+    }
+
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @ApiOperation(value = "체육관 상세 정보 조회", notes = "사용자(일반)가 체육관 상세 정보를 조회한다.")
+    @GetMapping("/{stadiumId}/info")
+    public ResponseEntity<?> getStadiumInfo(
+            @PathVariable Long stadiumId,
+            Pageable pageable
+    ) {
+        StadiumInfoResponseDto stadium = stadiumService.getStadiumInfo(stadiumId, pageable);
+        return ResponseEntity.ok().body(stadium);
     }
 
     @ApiOperation(value = "가까운 체육관 조회", notes = "사용자(일반)의 위도 경도를 기준으로 가까운 체육관을 조회한다.")

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Time;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,8 +17,8 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ApiModel(value = "체육관 정보 Response")
-public class StadiumResponseDto {
+@ApiModel(value = "체육관 상세 정보 조회 Response")
+public class StadiumInfoResponseDto {
     @ApiModelProperty(value = "체육관 ID", example = "1")
     private Long id;
 
@@ -39,28 +40,46 @@ public class StadiumResponseDto {
     @ApiModelProperty(value = "찜하기 수", example = "8")
     private Integer likes;
 
+    @ApiModelProperty(value = "평일 30분당 가격", example = "20000")
+    private Integer weekdayPricePerHalfHour;
+
+    @ApiModelProperty(value = "공휴일 30분당 가격", example = "30000")
+    private Integer holidayPricePerHalfHour;
+
     @ApiModelProperty(value = "이미지", example = "['img_url1', 'img_url2', ...]")
-    private StadiumImgDto.ImgResponse img; // TODO: 이미지주소 + public_id도 포함 필요
+    private List<StadiumImgDto.ImgResponse> imgs; // TODO: 이미지주소 + public_id도 포함 필요
     private List<String> tags;
 
+    @ApiModelProperty(value = "오픈 시간", example = "HH:MM:SS")
+    private Time openTime;
 
-    public static StadiumResponseDto fromEntity(Stadium stadium) {
-        return StadiumResponseDto.builder()
+    @ApiModelProperty(value = "마감 시간", example = "HH:MM:SS")
+    private Time closeTime;
+
+    public static StadiumInfoResponseDto fromEntity(Stadium stadium) {
+        return StadiumInfoResponseDto.builder()
                 .id(stadium.getId())
                 .name(stadium.getName())
                 .lat(stadium.getLat())
                 .lnt(stadium.getLnt())
                 .address(stadium.getAddress())
                 .star_avg(stadium.getStarAvg())
-                .img(stadium.getImgs().isEmpty() ?
+                .weekdayPricePerHalfHour(stadium.getWeekdayPricePerHalfHour())
+                .holidayPricePerHalfHour(stadium.getHolidayPricePerHalfHour())
+                .openTime(stadium.getOpenTime())
+                .closeTime(stadium.getCloseTime())
+                .imgs(stadium.getImgs().isEmpty() ?
                         null :
-                        StadiumImgDto.ImgResponse.builder()
-                                .publicId(stadium.getImgs().get(0).getImgId())
-                                .imgUrl(stadium.getImgs().get(0).getImgUrl())
-                                .build())
+                        stadium.getImgs().stream().map(img ->
+                                StadiumImgDto.ImgResponse.builder()
+                                        .publicId(img.getImgId())
+                                        .imgUrl(img.getImgUrl())
+                                        .build())
+                        .collect(Collectors.toList()))
                 .tags(stadium.getTags().stream().map(StadiumTag::getName).collect(Collectors.toList()))
                 // TODO: 찜하기 수 업데이트
                 // .likes(stadium.getLikes().size())
                 .build();
     }
+
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -133,7 +133,9 @@ public class Stadium {
     }
 
     public void update(StadiumDto.UpdateStadiumRequest request) {
+        System.out.println(request.getName());
         if (request.getName() != null) {
+            System.out.println("수정 중입니다만..." + request.getName());
             this.setName(request.getName());
         }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumDocument.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumDocument.java
@@ -23,6 +23,12 @@ public class StadiumDocument {
     private String address;
 
     @Field(type = FieldType.Double)
+    private Double lat;
+
+    @Field(type = FieldType.Double)
+    private Double lnt;
+
+    @Field(type = FieldType.Double)
     private Double starAvg;
 
     @Field(type = FieldType.Integer)
@@ -36,6 +42,8 @@ public class StadiumDocument {
                 .id(stadium.getId())
                 .name(stadium.getName())
                 .address(stadium.getAddress())
+                .lat(stadium.getLat())
+                .lnt(stadium.getLnt())
                 .starAvg(stadium.getStarAvg())
                 .weekdayPricePerHalfHour(stadium.getWeekdayPricePerHalfHour())
                 .holidayPricePerHalfHour(stadium.getHolidayPricePerHalfHour())

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumItemRepository.java
@@ -1,8 +1,12 @@
 package com.minwonhaeso.esc.stadium.repository;
 
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StadiumItemRepository extends JpaRepository<StadiumItem, Long> {
     void deleteByStadiumIdAndId(Long stadiumId, Long itemId);
+    List<StadiumItem> findAllByStadium(Stadium stadium);
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumSearchRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumSearchRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StadiumSearchRepository extends ElasticsearchRepository<StadiumDocument, Long> {
     Page<StadiumDocument> findByName(String name, Pageable pageable);
-
-    @Override
-    Page<StadiumDocument> searchSimilar(StadiumDocument entity, String[] fields, Pageable pageable);
+    Page<StadiumDocument> findByNameLikeOrAddressLike(String name, String address, Pageable pageable);
 }
+
+

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumTagRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumTagRepository.java
@@ -1,8 +1,12 @@
 package com.minwonhaeso.esc.stadium.repository;
 
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StadiumTagRepository extends JpaRepository<StadiumTag, Long> {
     void deleteByStadiumIdAndName(Long stadiumId, String tagName);
+    List<StadiumTag> findAllByStadium(Stadium stadium);
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumSearchService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumSearchService.java
@@ -28,8 +28,7 @@ public class StadiumSearchService {
     public Page<StadiumDocument> search(
             SearchStadiumDto.Request request,
             Pageable pageable) {
-//        return stadiumSearchRepository.findByName(request.getSearchValue(), pageable);
-        return stadiumSearchRepository.searchSimilar(
-                new StadiumDocument(), new String[] {request.getSearchValue()}, pageable);
+        String searchValue = request.getSearchValue();
+        return stadiumSearchRepository.findByNameLikeOrAddressLike(searchValue, searchValue, pageable);
     }
 }


### PR DESCRIPTION
### Background
---
- 체육관 정보 업데이트 및 삭제 시에 elasticsearch 레포에 반영하는 로직이 없었음
- 일반 사용자의 체육관 상세 정보 기능 및 권한 설정시에 인증과 연계 후 작업이 필요했음
- 체육관 매니저의 체육관 CRUD에 대한 권한 설정이 인증과 연계 후 작업이 필요했음

### Change
---
- [X] 체육관 정보 업데이트 및 삭제 시 검색용 DB도 반영되게끔 수정 완료
- [X] 일반 사용자의 체육관 상세 정보 조회 기능과 권한 설정 추가 완료
- [X] 체육관 매니저의 체육관 정보 CRUD에 대한 권한 설정 완료(업데이트 및 삭제시에 현재 토큰의 멤버아이디와 체육관에 등록된 멤버아이디를 비교)

### Test
---
- Postman 이용해서 CRUD 테스트 완료(주말 중에 테스트 코드 작성 예정)

### Discuss
---
- 권한 설정에서 PreAuthorize를 이용해서 1차로 권한이 없는 사람들을 거르고, 매니저의 체육관 CRUD에서 직접 AuthenticationPrincipal에서 멤버 정보를 가져와서 멤버 아이디를 비교하는 식으로 2차 권한 체크를 하였습니다! 혹시 더 좋은 방법이 있다면 알려주시면 바로 수정하겠습니다!
