### PR TITLE
Fix: Cache 관련 PrincipalDetail 설정 변경

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
@@ -11,9 +11,8 @@ public class InfoDto {
     @Getter
     @AllArgsConstructor
     public static class Response{
-        private String name;
+        private String nickName;
         private String email;
-        private String password;
         private String imgUrl;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
@@ -27,12 +27,14 @@ public class LoginDto {
         private String accessToken;
         private String refreshToken;
         private String name;
+        private String nickName;
         private String imgUrl;
 
 
-        public static Response of(String username, String imgUrl, String accessToken, String refreshToken) {
+        public static Response of(String username, String nickName, String imgUrl, String accessToken, String refreshToken) {
             return Response.builder()
                     .name(username)
+                    .nickName(nickName)
                     .imgUrl(imgUrl)
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)

--- a/src/main/java/com/minwonhaeso/esc/member/service/CustomerMemberDetailsService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/CustomerMemberDetailsService.java
@@ -3,7 +3,7 @@ package com.minwonhaeso.esc.member.service;
 import com.minwonhaeso.esc.error.exception.AuthException;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
-import com.minwonhaeso.esc.security.auth.PrincipalDetails;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.security.auth.redis.CacheKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -21,9 +21,9 @@ public class CustomerMemberDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    @Cacheable(value = CacheKey.USER, key = "#email", unless = "#result == null")
+    @Cacheable(value = CacheKey.USER, key = "#email")
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email).orElseThrow(() -> new AuthException(MemberNotFound));
-        return PrincipalDetails.of(member);
+        return PrincipalDetail.of(member);
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
@@ -41,8 +41,7 @@ public class PrincipalDetail implements UserDetails, OAuth2User {
         return Collections.singleton(new SimpleGrantedAuthority(this.role));
     }
     public static UserDetails of(Member member) {
-        UserDetails userDetails = new PrincipalDetail(member);
-        return userDetails;
+        return new PrincipalDetail(member);
     }
 
     @Override

--- a/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
@@ -1,7 +1,8 @@
 package com.minwonhaeso.esc.security.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.minwonhaeso.esc.member.model.entity.Member;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,64 +13,80 @@ import java.util.Collections;
 import java.util.Map;
 
 @Getter
-public class PrincipalDetails implements UserDetails, OAuth2User {
+@Setter
+@NoArgsConstructor
+public class PrincipalDetail implements UserDetails, OAuth2User {
 
-    private final Member member;
+    private String username;
+    private String password;
+    private String role;
     private Map<String, Object> attributes;
 
-    public PrincipalDetails(Member member) {
-        this.member = member;
+    public PrincipalDetail(Member member) {
+        this.username = member.getEmail();
+        this.password = member.getPassword();
+        this.role = member.getRole().name();
     }
 
-    public PrincipalDetails(Member member, Map<String, Object> attributes) {
-        this.member = member;
+    public PrincipalDetail(Member member, Map<String, Object> attributes) {
+        this.username = member.getEmail();
+        this.password = member.getPassword();
+        this.role = member.getRole().name();
         this.attributes = attributes;
     }
 
     @Override
+    @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(this.member.getRole().name()));
+        return Collections.singleton(new SimpleGrantedAuthority(this.role));
     }
     public static UserDetails of(Member member) {
-        return new PrincipalDetails(member);
+        UserDetails userDetails = new PrincipalDetail(member);
+        return userDetails;
     }
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return password;
     }
 
     @Override
     public String getUsername() {
-        return member.getEmail();
+        return username;
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonExpired() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isAccountNonLocked() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isCredentialsNonExpired() {
         return true;
     }
 
     @Override
+    @JsonIgnore
     public boolean isEnabled() {
         return true;
     }
 
     @Override
+//    @JsonIgnore
     public Map<String, Object> getAttributes() {
         return attributes;
     }
 
     @Override
+    @JsonIgnore
     public String getName() {
         return null;
     }

--- a/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtTokenUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtTokenUtil.java
@@ -62,10 +62,10 @@ public class JwtTokenUtil {
     private String doGenerateToken(String email, long expireTime) {
         Claims claims = Jwts.claims();
         claims.put("email", email);
-
+        Date curTime = new Date(System.currentTimeMillis());
         return Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setIssuedAt(curTime)
                 .setExpiration(new Date(System.currentTimeMillis() + expireTime))
                 .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/com/minwonhaeso/esc/security/auth/redis/CacheConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/redis/CacheConfig.java
@@ -42,12 +42,10 @@ public class CacheConfig {
                         .SerializationPair
                         .fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
-
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(configuration)
                 .build();
-
     }
 
     @Bean

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/service/CustomerOAuth2MemberService.java
@@ -7,7 +7,7 @@ import com.minwonhaeso.esc.member.model.type.MemberRole;
 import com.minwonhaeso.esc.member.model.type.MemberStatus;
 import com.minwonhaeso.esc.member.model.type.MemberType;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
-import com.minwonhaeso.esc.security.auth.PrincipalDetails;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;
 import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
@@ -69,7 +69,7 @@ public class CustomerOAuth2MemberService extends DefaultOAuth2UserService {
 
         log.info("processOAuth2User :" + member);
 
-        return new PrincipalDetails(member, oAuth2User.getAttributes());
+        return new PrincipalDetail(member, oAuth2User.getAttributes());
     }
 
     private Member registerMember(OAuth2MemberInfo memberInfo, ProviderType providerType) {


### PR DESCRIPTION
### Background
---
Token을 사용하는 서비스를 이용할 때 만들어진 UserDetails cache가 deserialize가 안 되는 문제가 있었음.

### Change
---
PrincipalDetail 파일의 변수를 지역변수들로 바꾸고, 필요없는 내용들에 @JasonIgnore
loadByUsername메소드의 반환타입을 PrincipalDetail에서 UserDetails로 변경

### Test
---
postman을 통한 테스트 성공

### Analatics
---
PrincipalDetail에서 클래스를 변수로 가지고 있을 경우도 확인해 봐야한다.

### Discuss
---
- 

### Reference
---
- 
