### PR TITLE
Refactor : 전체적인 리팩토링 진행

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/config/CacheConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/config/CacheConfig.java
@@ -1,5 +1,6 @@
-package com.minwonhaeso.esc.security.auth.redis;
+package com.minwonhaeso.esc.config;
 
+import com.minwonhaeso.esc.security.auth.redis.CacheKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;

--- a/src/main/java/com/minwonhaeso/esc/config/ElasticsearchConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/config/ElasticsearchConfig.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.common.config;
+package com.minwonhaeso.esc.config;
 
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/minwonhaeso/esc/config/QuerydslConfiguration.java
+++ b/src/main/java/com/minwonhaeso/esc/config/QuerydslConfiguration.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.common.config;
+package com.minwonhaeso.esc.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/minwonhaeso/esc/config/SwaggerConfig.java
+++ b/src/main/java/com/minwonhaeso/esc/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.common.swagger;
+package com.minwonhaeso.esc.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/minwonhaeso/esc/mail/MailService.java
+++ b/src/main/java/com/minwonhaeso/esc/mail/MailService.java
@@ -1,15 +1,15 @@
-package com.minwonhaeso.esc.component;
+package com.minwonhaeso.esc.mail;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
-@Component
-public class MailComponents {
+@Service
+public class MailService {
     private final JavaMailSender javaMailSender;
 
     public boolean sendMail(String mail, String subject, String text) {

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -4,13 +4,12 @@ import com.minwonhaeso.esc.member.model.dto.LoginDto;
 import com.minwonhaeso.esc.member.model.dto.SignDto;
 import com.minwonhaeso.esc.member.model.dto.TokenDto;
 import com.minwonhaeso.esc.member.service.MemberService;
-import com.minwonhaeso.esc.security.auth.jwt.JwtTokenUtil;
+import com.minwonhaeso.esc.util.JwtTokenUtil;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @RestController

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
@@ -26,6 +26,7 @@ public class SignDto {
     @NoArgsConstructor
     public static class Response {
         private String name;
+        private String nickName;
         private String image;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -35,8 +35,6 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
-    @NotNull
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -22,25 +22,24 @@ import javax.persistence.*;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
     private Long memberId;
 
-    @Column(unique = true, name = "email")
+    @Column(unique = true)
     private String email;
 
     @NotNull
-    @Column(name = "name")
+    @Column(nullable = false)
     private String name;
 
     @NotNull
-    @Column(name = "password")
+    @Column(nullable = false)
     private String password;
 
+    @NotNull
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
-
-    @Column(name = "img_url")
     private String imgUrl;
 
     @Column(unique = true)
@@ -55,7 +54,6 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private ProviderType providerType; // 소셜 타입
 
-    @Column(name = "provider_id")
     private String providerId;
 
 

--- a/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/PrincipalDetail.java
@@ -19,26 +19,26 @@ public class PrincipalDetail implements UserDetails, OAuth2User {
 
     private String username;
     private String password;
-    private String role;
+    private Member member;
     private Map<String, Object> attributes;
 
     public PrincipalDetail(Member member) {
         this.username = member.getEmail();
         this.password = member.getPassword();
-        this.role = member.getRole().name();
+        this.member = member;
     }
 
     public PrincipalDetail(Member member, Map<String, Object> attributes) {
         this.username = member.getEmail();
         this.password = member.getPassword();
-        this.role = member.getRole().name();
         this.attributes = attributes;
+        this.member = member;
     }
 
     @Override
     @JsonIgnore
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(this.role));
+        return Collections.singleton(new SimpleGrantedAuthority(this.member.getRole().name()));
     }
     public static UserDetails of(Member member) {
         return new PrincipalDetail(member);

--- a/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.security.auth.jwt;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.member.service.CustomerMemberDetailsService;
 import com.minwonhaeso.esc.security.auth.redis.LogoutAccessTokenRedisRepository;
+import com.minwonhaeso.esc.util.JwtTokenUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/minwonhaeso/esc/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,6 @@
 package com.minwonhaeso.esc.security.oauth2.handler;
 
-import com.minwonhaeso.esc.security.auth.jwt.JwtTokenUtil;
+import com.minwonhaeso.esc.util.JwtTokenUtil;
 import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfo;
 import com.minwonhaeso.esc.security.oauth2.info.OAuth2MemberInfoFactory;

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -1,7 +1,7 @@
 package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
-import com.minwonhaeso.esc.security.auth.PrincipalDetails;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.stadium.model.dto.*;
 import com.minwonhaeso.esc.stadium.service.StadiumService;
 import io.swagger.annotations.ApiOperation;
@@ -24,7 +24,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "등록 체육관 조회", notes = "사용자(매니저)가 등록한 체육관을 조회한다.")
     @GetMapping("/manager")
     public ResponseEntity<?> getAllRegisteredStadiumsByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             Pageable pageable
     ) {
         Member member = principalDetails.getMember();
@@ -36,7 +36,7 @@ public class StadiumManagerController {
     @PostMapping("/register")
     public ResponseEntity<?> createStadiumByManager(
             @RequestBody StadiumDto.CreateStadiumRequest request,
-            @AuthenticationPrincipal PrincipalDetails principalDetails
+            @AuthenticationPrincipal PrincipalDetail principalDetails
             ) {
         Member member = principalDetails.getMember();
         StadiumDto.CreateStadiumResponse stadium = stadiumService.createStadium(request, member);
@@ -46,7 +46,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 정보 수정", notes = "사용자(매니저)가 등록한 체육관의 정보를 수정한다.")
     @PatchMapping("/{stadiumId}/info")
     public ResponseEntity<?> updateStadiumInfo(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumDto.UpdateStadiumRequest request
     ) {
@@ -58,7 +58,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 이미지 추가", notes = "사용자(매니저)가 등록한 체육관의 이미지를 1장 추가한다.")
     @PostMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> addStadiumImgByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumImgDto.AddImgRequest request
     ) {
@@ -70,7 +70,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 종목(태그) 추가", notes = "사용자(매니저)가 등록한 체육관의 종목을 1개 추가한다.")
     @PostMapping("/{stadiumId}/tags")
     public ResponseEntity<?> addStadiumTagByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumTagDto.AddTagRequest request
     ) {
@@ -92,7 +92,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 이미지 삭제", notes = "사용자(매니저)가 등록한 체육관의 이미지 1장을 삭제한다.")
     @DeleteMapping("/{stadiumId}/imgs")
     public ResponseEntity<?> deleteStadiumImgByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumImgDto.DeleteImgRequest request
     ) {
@@ -104,7 +104,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 종목(태그) 삭제", notes = "사용자(매니저)가 등록한 체육관의 종목 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/tags")
     public ResponseEntity<?> deleteStadiumTagByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumTagDto.DeleteTagRequest request
     ) {
@@ -116,7 +116,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 대여 용품 삭제", notes = "사용자(매니저)가 등록한 체육관의 대여 용품 1개를 삭제한다.")
     @DeleteMapping("/{stadiumId}/items")
     public ResponseEntity<?> deleteStadiumItemByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId,
             @RequestBody StadiumItemDto.DeleteItemRequest request) {
         Member member = principalDetails.getMember();
@@ -127,7 +127,7 @@ public class StadiumManagerController {
     @ApiOperation(value = "체육관 삭제", notes = "사용자(매니저)가 등록한 체육관을 삭제한다.")
     @DeleteMapping("/{stadiumId}/info")
     public ResponseEntity<?> deleteStadiumByManager(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @AuthenticationPrincipal PrincipalDetail principalDetails,
             @PathVariable Long stadiumId) {
         Member member = principalDetails.getMember();
         stadiumService.deleteStadium(member, stadiumId);

--- a/src/main/java/com/minwonhaeso/esc/util/AuthUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/util/AuthUtil.java
@@ -1,12 +1,15 @@
-package com.minwonhaeso.esc.security.auth;
+package com.minwonhaeso.esc.util;
 
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthUtil {
 
-    public String generateEmailAuthNum() {
+    public static String generateEmailAuthNum() {
         java.util.Random generator = new java.util.Random();
         generator.setSeed(System.currentTimeMillis());
         return String.valueOf(generator.nextInt(1000000) % 1000000);

--- a/src/main/java/com/minwonhaeso/esc/util/JwtTokenUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/util/JwtTokenUtil.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.security.auth.jwt;
+package com.minwonhaeso.esc.util;
 
 import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
 import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;

--- a/src/main/java/com/minwonhaeso/esc/util/LocationUtils.java
+++ b/src/main/java/com/minwonhaeso/esc/util/LocationUtils.java
@@ -1,4 +1,4 @@
-package com.minwonhaeso.esc.stadium.util;
+package com.minwonhaeso.esc.util;
 
 import lombok.Builder;
 import lombok.Data;


### PR DESCRIPTION


### Background
---
* PrincipalDetails 클래스에 불필요한 복수 class name이 사용되었다.
* Mail에 관한 Service를 제공하는 클래스가 Component로 사용 됐었다.
* Member entity에 불필요한 컬럼 어노테이션들이 들어가 있었다.
* AuthUtil을 객체를 생성하는 방식으로 사용하고 있었다.
* config와 util 클래스들이 각각 쓰여지는 domain 안에 흩어져 있었다.

### Change
---
* PrincipalDetails 클래스 명  PrincipalDetail로 변경
* MailComponents 클래스 명 MailService로 변경하고, Bean등록 방식을 Component에서 Service로 변경, component라는 패키지에서 mail 패키지로 변경
* Member entity 불필요한 컬럼 어노테이션 삭제(nullable이 필요한 경우만 사용)
* AuthUtil accessLEVEL.private 설정 및 static 메소드로 전환
* common패키지 삭제, config와 util 패키지 최상단 위치 및 모든 config, util 파일 위치 리펙토리

### Analatics
---
* 아직 유틸들 중에 LocationUtils와 JwtTokenUtil파일은 static 메소드로 전환하지 않았습니다. 이 부분은 필요할지 의논 필요
* 지금 LocationUtils도 복수 클래스 명으로 되어있는데 이 부분도 PrincipalDetail  처럼 변경하는 것이 좋을지
* 다른 분들의 코드는 웬만하면 안 건드렸습니다.


### Discuss
---
* mail패키지 이름이 뭔가 걸리네요. 혹시 괜찮은 의견 있으시면 남겨주세요
* 리뷰 받은 내용으롤 수정해 봤는데, 혹시 개선해야 할 부분들이 있으면 코멘트 남겨주세요.


### Reference
---
[멘토님 피드백 page](https://spotty-archer-150.notion.site/FE-BE-e19e564ac5ea472a9f485c3bfc645f5b )