### PR TITLE
Fix : 이메일 인증번호 생성 로직 및 로그아웃 헤더 수정

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -76,10 +76,9 @@ public class MemberController {
      **/
     @ApiOperation(value = "로그아웃", notes = "사용자의 로그아웃")
     @PostMapping("/auth/logout")
-    public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
-                                    @RequestHeader("RefreshToken") String refreshToken) {
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken) {
         String username = jwtTokenUtil.getUsername(resolveToken(accessToken));
-        Map<String, String> result = memberService.logout(TokenDto.of(accessToken, refreshToken), username);
+        Map<String, String> result = memberService.logout(TokenDto.of(accessToken), username);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/TokenDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/TokenDto.java
@@ -21,4 +21,10 @@ public class TokenDto {
                 .refreshToken(refreshToken)
                 .build();
     }
+    public static TokenDto of(String accessToken) {
+        return TokenDto.builder()
+                .grantType(GRANT_TYPE.getValue())
+                .accessToken(accessToken)
+                .build();
+    }
 }

--- a/src/main/java/com/minwonhaeso/esc/util/AuthUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/util/AuthUtil.java
@@ -12,6 +12,13 @@ public class AuthUtil {
     public static String generateEmailAuthNum() {
         java.util.Random generator = new java.util.Random();
         generator.setSeed(System.currentTimeMillis());
-        return String.valueOf(generator.nextInt(1000000) % 1000000);
+        String result =  String.valueOf(generator.nextInt(1000000) % 1000000);
+        if(result.length() !=6){
+            for (int i = 0; i < 6 - result.length(); i++) {
+                result = "0" + result;
+            }
+        }
+        return result;
     }
+
 }

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
@@ -4,7 +4,6 @@ import com.minwonhaeso.esc.error.exception.AuthException;
 import com.minwonhaeso.esc.error.type.AuthErrorCode;
 import com.minwonhaeso.esc.member.model.dto.SignDto;
 import com.minwonhaeso.esc.member.model.entity.Member;
-import com.minwonhaeso.esc.member.model.type.MemberType;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ class MemberServiceTest {
                 .email("ESC@gmail.com")
                 .name("ESC_TEST")
                 .password("1111")
-                .type(MemberType.ADMIN)
+                .type("USER")
                 .nickname("ESC")
                 .image("/ESC/test/image.img")
                 .build();

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
@@ -80,7 +80,7 @@ class MemberServiceWithPrincipalTest {
         //then
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
-        assertEquals(response.getName(), member.getName());
+        assertEquals(response.getNickName(), member.getNickname());
     }
 
     @Test


### PR DESCRIPTION
### Background
---
* AuthUtil의 generateEmailAuthNum 메소드에서 인증번호가 6자리가 아닌 4자리 or 5자리가 반환되는 경우가 발생했음
* Logout API에서 필요 없는 RefreshToken을 RequestHeader로 받고있었다.
* TestCode 오류해결

### Change
---
* AuthUtil generateEmailAuthNum 메소드 에러  자릿 수에 따라서 앞에 0을 추가하는 방식으로 수정
* Logout API에서 RequestHeader로 RefreshToken 받아오던 로직 삭제

### Test
---
* 기존 TestCode에서 수정된 내용 반영
 


