### PR TITLE
Feat : 예약 도메인 셋팅(Model, Controller, Service, Repository)

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
@@ -1,0 +1,34 @@
+package com.minwonhaeso.esc.stadium.controller;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto;
+import com.minwonhaeso.esc.stadium.service.StadiumReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+@RequestMapping("/stadiums")
+@Controller
+public class StadiumReservationController {
+    private final StadiumReservationService stadiumReservationService;
+
+    @GetMapping("/reservations")
+    public ResponseEntity<?> getAllReservations(
+            @AuthenticationPrincipal PrincipalDetail principalDetail,
+            Pageable pageable
+    ) {
+        Member member = principalDetail.getMember();
+        Page<StadiumReservationDto.Response> reservations =
+                stadiumReservationService.getAllReservationsByMember(member, pageable);
+        return ResponseEntity.ok().body(reservations);
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
@@ -1,0 +1,79 @@
+package com.minwonhaeso.esc.stadium.model.dto;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumItem;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StadiumReservationDto {
+    @Data
+    @Builder
+    public static class Response {
+        private Long id;
+        private StadiumResponseDto stadium;
+        private MemberResponseDto member;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private int headCount;
+        private int price;
+        private String paymentType;
+        private List<ItemResponseDto> items;
+
+        public static Response fromEntity(StadiumReservation reservation) {
+            return Response.builder()
+                    .id(reservation.getId())
+                    .stadium(StadiumResponseDto.fromEntity(reservation.getStadium()))
+                    .member(MemberResponseDto.fromEntity(reservation.getMember()))
+                    .startDate(reservation.getStartDate())
+                    .endDate(reservation.getEndDate())
+                    .headCount(reservation.getHeadCount())
+                    .price(reservation.getPrice())
+                    .paymentType(reservation.getPaymentType().toString())
+                    .items(ItemResponseDto.fromReservation(reservation))
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    private static class ItemResponseDto {
+        private Long id;
+        private String name;
+        private String imgUrl;
+        private int price;
+        private int count;
+
+        public static List<ItemResponseDto> fromReservation(StadiumReservation reservation) {
+            return reservation.getItems().stream().map(reservationItem -> {
+                StadiumItem item = reservationItem.getItem();
+                return ItemResponseDto.builder()
+                        .id(item.getId())
+                        .name(item.getName())
+                        .imgUrl(item.getImgUrl())
+                        .price(item.getPrice())
+                        .count(reservationItem.getCount())
+                        .build();
+            }).collect(Collectors.toList());
+        }
+    }
+
+    @Data
+    @Builder
+    private static class MemberResponseDto {
+        private Long id;
+        private String nickname;
+        private String email;
+
+        public static MemberResponseDto fromEntity(Member member) {
+            return MemberResponseDto.builder()
+                    .id(member.getMemberId())
+                    .nickname(member.getNickname())
+                    .email(member.getEmail())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
@@ -1,0 +1,60 @@
+package com.minwonhaeso.esc.stadium.model.entity;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.type.PaymentType;
+import com.minwonhaeso.esc.stadium.model.type.StadiumReservationStatus;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StadiumReservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+    @Column(nullable = false)
+    private int price;
+
+    @ApiModelProperty(name = "인원수")
+    private int headCount;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StadiumReservationStatus status;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "reservation")
+    private List<StadiumReservationItem> items = new ArrayList<>();
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @ApiModelProperty(name = "결제 타입")
+    private PaymentType paymentType;
+
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservationCancel.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservationCancel.java
@@ -1,0 +1,28 @@
+package com.minwonhaeso.esc.stadium.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StadiumReservationCancel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private StadiumReservation reservation;
+
+    @Column(nullable = false)
+    private int price;
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservationItem.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservationItem.java
@@ -1,0 +1,32 @@
+package com.minwonhaeso.esc.stadium.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class StadiumReservationItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id", nullable = false)
+    private StadiumItem item;
+
+    @ManyToOne
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private StadiumReservation reservation;
+
+    private int count;
+    private int price;
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/type/PaymentType.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/type/PaymentType.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.stadium.model.type;
+
+public enum PaymentType {
+    CARD, CASH
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/type/StadiumReservationStatus.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/type/StadiumReservationStatus.java
@@ -1,0 +1,5 @@
+package com.minwonhaeso.esc.stadium.model.type;
+
+public enum StadiumReservationStatus {
+    RESERVED, EXECUTED, EXPIRED, CANCELED
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationCancelRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationCancelRepository.java
@@ -1,0 +1,9 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.stadium.model.entity.StadiumReservationCancel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StadiumReservationCancelRepository extends JpaRepository<StadiumReservationCancel, Long> {
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationItemRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationItemRepository.java
@@ -1,0 +1,9 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.stadium.model.entity.StadiumReservationItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StadiumReservationItemRepository extends JpaRepository<StadiumReservationItem, Long> {
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
@@ -1,0 +1,16 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface StadiumReservationRepository extends JpaRepository<StadiumReservation, Long> {
+    Page<StadiumReservation> findAllByMemberAndStatusAndStartDateAfter(
+            Member member, String status, LocalDateTime today, Pageable pageable);
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumReservationService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumReservationService.java
@@ -1,0 +1,31 @@
+package com.minwonhaeso.esc.stadium.service;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto;
+import com.minwonhaeso.esc.stadium.model.type.StadiumReservationStatus;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationCancelRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationItemRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class StadiumReservationService {
+    private final StadiumReservationRepository stadiumReservationRepository;
+    private final StadiumReservationItemRepository stadiumReservationItemRepository;
+    private final StadiumReservationCancelRepository stadiumReservationCancelRepository;
+
+    public Page<StadiumReservationDto.Response> getAllReservationsByMember(Member member, Pageable pageable) {
+        return stadiumReservationRepository
+                .findAllByMemberAndStatusAndStartDateAfter(
+                        member,
+                        StadiumReservationStatus.RESERVED.toString(),
+                        LocalDateTime.now(),
+                        pageable).map(StadiumReservationDto.Response::fromEntity);
+    }
+}


### PR DESCRIPTION
## 예약 도메인 셋팅(Model, Controller, Service, Repository) + 사용자 전체 예약내역 조회 기능 구현
---

### Background
---
- 체육관 예약 기능 구현 시작

### Change
---
- 전체적인 틀(Model, Controller, Service, Repository) 구현
- 사용자의 전체 예약 내역 조회 기능 구현

### Test
---
- 기본적인 CRUD 완성 후 Postman 테스트 진행하겠습니다.

### Discuss
---
- Dto 짤 때 항상 느끼는 거지만,,, lombok은 사랑입니다.
- 예약을 가져올 때 사용자에 대한 상세 정보를 늦게 가져와도 될 것 같아서 
  FetchType의 Lazy Loading을 넣어보았습니다! 
  (심심할 때 Eager vs Lazy 한번 더 반복학습 할 수 있게 관련자료 첨부했습니다)

### Reference
---
- [Eager / Lazy Loading](https://zzang9ha.tistory.com/347)
