### PR TITLE
Feat : 리뷰 도메인 셋팅 및 회원 관련 리팩토링

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
@@ -11,7 +11,7 @@ public class InfoDto {
     @Getter
     @AllArgsConstructor
     public static class Response{
-        private String nickName;
+        private String nickname;
         private String email;
         private String imgUrl;
     }

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
@@ -27,14 +27,14 @@ public class LoginDto {
         private String accessToken;
         private String refreshToken;
         private String name;
-        private String nickName;
+        private String nickname;
         private String imgUrl;
 
 
-        public static Response of(String username, String nickName, String imgUrl, String accessToken, String refreshToken) {
+        public static Response of(String username, String nickname, String imgUrl, String accessToken, String refreshToken) {
             return Response.builder()
                     .name(username)
-                    .nickName(nickName)
+                    .nickname(nickname)
                     .imgUrl(imgUrl)
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/OAuthDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/OAuthDto.java
@@ -22,7 +22,7 @@ public class OAuthDto {
     @NoArgsConstructor
     @ApiModel(value = "소셜 로그인 Response Body")
     public static class Response {
-        private String nickName;
+        private String nickname;
         private String imgUrl;
         private String refreshToken;
     }

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/SignDto.java
@@ -26,7 +26,7 @@ public class SignDto {
     @NoArgsConstructor
     public static class Response {
         private String name;
-        private String nickName;
+        private String nickname;
         private String image;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
         Member member = Member.of(signDto);
         memberRepository.save(member);
         return SignDto.Response.builder()
-                .nickName(member.getNickname())
+                .nickname(member.getNickname())
                 .name(member.getName())
                 .image(member.getImgUrl())
                 .build();
@@ -140,7 +140,7 @@ public class MemberService {
         Member member = memberRepository.findByEmail(user.getUsername())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
         return InfoDto.Response.builder()
-                .nickName(member.getNickname())
+                .nickname(member.getNickname())
                 .email(member.getEmail())
                 .imgUrl(member.getImgUrl())
                 .build();
@@ -245,7 +245,7 @@ public class MemberService {
         RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(email);
 
         return OAuthDto.Response.builder()
-                .nickName(member.getNickname())
+                .nickname(member.getNickname())
                 .imgUrl(member.getImgUrl())
                 .refreshToken(refreshToken.getRefreshToken())
                 .build();

--- a/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
+++ b/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
@@ -1,0 +1,60 @@
+package com.minwonhaeso.esc.review.controller;
+
+import com.minwonhaeso.esc.review.model.dto.ReviewDto;
+import com.minwonhaeso.esc.review.service.ReviewService;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/stadiums")
+@RestController
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("/{stadiumId}/reviews")
+    public ResponseEntity<?> getAllReviews(
+            @PathVariable Long stadiumId,
+            Pageable pageable
+    ) {
+        Page<ReviewDto.Response> reviews = reviewService.getAllReviewsByStadium(stadiumId, pageable);
+        return ResponseEntity.ok().body(reviews);
+    }
+
+    @PostMapping("/{stadiumId}/reviews")
+    public ResponseEntity<?> createReview(
+            @AuthenticationPrincipal PrincipalDetail principalDetail,
+            @PathVariable Long stadiumId,
+            @RequestBody ReviewDto.Request request
+    ) {
+        // TODO 리뷰 등록
+        return null;
+    }
+
+    @DeleteMapping("/{stadiumId}/reviews/{reviewId}")
+    public ResponseEntity<?> deleteReview(
+            @AuthenticationPrincipal PrincipalDetail principalDetail,
+            @PathVariable(value = "stadiumId") Long stadiumId,
+            @PathVariable("reviewId") Long reviewId,
+            @RequestBody ReviewDto.Request request
+    ) {
+        // TODO 리뷰 삭제 (+ PathVariable 방식 수정)
+        return null;
+    }
+
+    @PatchMapping("/{stadiumId}/reviews/{reviewId}")
+    public ResponseEntity<?> updateReview(
+            @AuthenticationPrincipal PrincipalDetail principalDetail,
+            @PathVariable(value = "stadiumId") Long stadiumId,
+            @PathVariable("reviewId") Long reviewId,
+            @RequestBody ReviewDto.Request request
+    ) {
+        // TODO 리뷰 수정 (+ PathVariable 방식 수정)
+        return null;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -1,0 +1,34 @@
+package com.minwonhaeso.esc.review.model.dto;
+
+import com.minwonhaeso.esc.review.model.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReviewDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private long star;
+        private String comment;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private long star;
+        private String comment;
+
+        public static ReviewDto.Response fromEntity(Review review) {
+            return Response.builder()
+                    .star(review.getStar())
+                    .comment(review.getComment())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -12,7 +12,7 @@ public class ReviewDto {
     @AllArgsConstructor
     @Builder
     public static class Request {
-        private long star;
+        private float star;
         private String comment;
     }
 
@@ -21,7 +21,7 @@ public class ReviewDto {
     @AllArgsConstructor
     @Builder
     public static class Response {
-        private long star;
+        private float star;
         private String comment;
 
         public static ReviewDto.Response fromEntity(Review review) {

--- a/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
@@ -1,0 +1,49 @@
+package com.minwonhaeso.esc.review.model.entity;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.sun.istack.NotNull;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @NotNull
+    private long star;
+    private String comment;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public void update(long star, String comment) {
+        this.star = star;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
@@ -33,7 +33,7 @@ public class Review {
     private Member member;
 
     @NotNull
-    private long star;
+    private float star;
     private String comment;
 
     @CreatedDate
@@ -42,7 +42,7 @@ public class Review {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public void update(long star, String comment) {
+    public void update(float star, String comment) {
         this.star = star;
         this.comment = comment;
     }

--- a/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package com.minwonhaeso.esc.review.repository;
+
+import com.minwonhaeso.esc.review.model.entity.Review;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Override
+    Page<Review> findAll(Pageable pageable);
+    Page<Review> findAllByStadium(Stadium stadium, Pageable pageable);
+}

--- a/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
+++ b/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
@@ -1,0 +1,30 @@
+package com.minwonhaeso.esc.review.service;
+
+import com.minwonhaeso.esc.error.exception.StadiumException;
+import com.minwonhaeso.esc.error.type.StadiumErrorCode;
+import com.minwonhaeso.esc.review.model.dto.ReviewDto;
+import com.minwonhaeso.esc.review.repository.ReviewRepository;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    private final StadiumRepository stadiumRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ReviewDto.Response> getAllReviewsByStadium(Long stadiumId, Pageable pageable) {
+        Stadium stadium = stadiumRepository.findById(stadiumId)
+                .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
+
+        return reviewRepository.findAllByStadium(stadium, pageable).map(ReviewDto.Response::fromEntity);
+    }
+
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.stadium.model.entity;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.review.model.entity.Review;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumDto;
 import com.sun.istack.NotNull;
 import lombok.*;
@@ -95,9 +96,9 @@ public class Stadium {
     @OneToMany(mappedBy = "stadium")
     private List<StadiumTag> tags = new ArrayList<>();
 
-//    @OneToMany(mappedBy = "stadium")
-//    @Column(name = "reviews")
-//    private List<Review> reviews;
+    @OneToMany(mappedBy = "stadium")
+    @Column(name = "reviews")
+    private List<Review> reviews;
 
     @CreatedDate
     private LocalDateTime createdAt;


### PR DESCRIPTION
### Background
---
- UI 테스트 과정에서 nickname 및 nickName과 같이 통일되지 않은 필드명으로 문제를 겪었음
- 리뷰 API 구현 시작

### Change
---
- column 및 필드명을 nickname으로 통일함
- 리뷰 관련 Model, Service, Controller 등 기본적인 셋팅 진행
- 체육관별 전체 리뷰 조회 기능 구현

### Discuss
---
- 리뷰 등록 시, 예약한 이력을 확인하는 로직이 필요한 지 고민 중입니다. 의견 부탁드립니다!
   - 체육관을 예약/사용한 이력이 있어야 리뷰를 달 수 있도록 하는 것이 좋을지
   - 본 서비스 외에서 체육관을 사용하였더라도 리뷰 등록이 가능한지 
     - 만약 해당 방식으로 한다면 리뷰 횟수를 1회로 제한하는 것이 좋을 것 같습니다. 
 <br>

- 리뷰 등록의 경우, 횟수 고려 사항도 혹시 의견 있으시다면 부탁드립니다! 
  - 한 체육관에 대하여 리뷰를 1번 남기게 제한을 둘 것인지
  - 추후 다시 예약하여 또 사용할 수 있으니, 횟수에 대한 제한은 필요가 없을지

### Reference
---
- Mapping 경로에 2개의 변수가 필요한 상황(stadiumId 및 reviewId)으로 관련 자료를 다시 찾아보았습니다.
  - [Parameter Mapping](https://bamdule.tistory.com/131)
  - [@RequestParam vs @PathVariable](https://velog.io/@dongscholes/JavaSpringBoot-RequestParam-vs-PathVariable-%EC%93%B0%EC%9E%84%EC%83%88-%EC%82%AC%EC%9A%A9%EB%B2%95-%EC%B0%A8%EC%9D%B4%EC%A0%90)
