### PR TITLE
Feat : 리뷰 CRUD 구현

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/exception/ReviewException.java
+++ b/src/main/java/com/minwonhaeso/esc/error/exception/ReviewException.java
@@ -1,0 +1,15 @@
+package com.minwonhaeso.esc.error.exception;
+
+import com.minwonhaeso.esc.error.type.ReviewErrorCode;
+import com.minwonhaeso.esc.error.type.StadiumErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ReviewException extends RuntimeException{
+    private final ReviewErrorCode errorCode;
+
+    public ReviewException(ReviewErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/error/type/ReviewErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/ReviewErrorCode.java
@@ -1,0 +1,17 @@
+package com.minwonhaeso.esc.error.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode {
+    ReviewNotFound(HttpStatus.BAD_REQUEST, "일치하는 리뷰 정보가 존재하지 않습니다."),
+    ReviewCountOverReservation(HttpStatus.BAD_REQUEST, "입력 가능한 모든 리뷰를 작성하였습니다."),
+    NoReservationForReview(HttpStatus.BAD_REQUEST, "예약 내역이 존재하지 않습니다."),
+    UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
+
+    private final HttpStatus statusCode;
+    private final String errorMessage;
+}

--- a/src/main/java/com/minwonhaeso/esc/error/type/ReviewErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/ReviewErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ReviewErrorCode {
     ReviewNotFound(HttpStatus.BAD_REQUEST, "일치하는 리뷰 정보가 존재하지 않습니다."),
     ReviewCountOverReservation(HttpStatus.BAD_REQUEST, "입력 가능한 모든 리뷰를 작성하였습니다."),
-    NoReservationForReview(HttpStatus.BAD_REQUEST, "예약 내역이 존재하지 않습니다."),
+    NoReservationForReview(HttpStatus.BAD_REQUEST, "예약(사용) 내역이 존재하지 않습니다."),
     UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
 
     private final HttpStatus statusCode;

--- a/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
+++ b/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
@@ -1,12 +1,15 @@
 package com.minwonhaeso.esc.review.controller;
 
+import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.dto.ReviewDto;
 import com.minwonhaeso.esc.review.service.ReviewService;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,35 +29,40 @@ public class ReviewController {
         return ResponseEntity.ok().body(reviews);
     }
 
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/{stadiumId}/reviews")
     public ResponseEntity<?> createReview(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
             @PathVariable Long stadiumId,
             @RequestBody ReviewDto.Request request
     ) {
-        // TODO 리뷰 등록
-        return null;
+        Member member = principalDetail.getMember();
+        ReviewDto.Response review = reviewService.createReview(request, member, stadiumId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(review);
     }
 
+    @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/{stadiumId}/reviews/{reviewId}")
     public ResponseEntity<?> deleteReview(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
-            @PathVariable(value = "stadiumId") Long stadiumId,
-            @PathVariable("reviewId") Long reviewId,
-            @RequestBody ReviewDto.Request request
+            @PathVariable Long stadiumId,
+            @PathVariable Long reviewId
     ) {
-        // TODO 리뷰 삭제 (+ PathVariable 방식 수정)
-        return null;
+        Member member = principalDetail.getMember();
+        reviewService.deleteReview(member, stadiumId, reviewId);
+        return ResponseEntity.ok().build();
     }
 
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/{stadiumId}/reviews/{reviewId}")
     public ResponseEntity<?> updateReview(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
-            @PathVariable(value = "stadiumId") Long stadiumId,
-            @PathVariable("reviewId") Long reviewId,
+            @PathVariable Long stadiumId,
+            @PathVariable Long reviewId,
             @RequestBody ReviewDto.Request request
     ) {
-        // TODO 리뷰 수정 (+ PathVariable 방식 수정)
-        return null;
+        Member member = principalDetail.getMember();
+        ReviewDto.Response review = reviewService.updateReview(request, member, stadiumId, reviewId);
+        return ResponseEntity.ok().body(review);
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
+++ b/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
@@ -4,6 +4,8 @@ import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.dto.ReviewDto;
 import com.minwonhaeso.esc.review.service.ReviewService;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +22,7 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @ApiOperation(value = "리뷰 조회", notes = "사용자(일반&매니저)가 리뷰를 조회한다.")
     @GetMapping("/{stadiumId}/reviews")
     public ResponseEntity<?> getAllReviews(
             @PathVariable Long stadiumId,
@@ -29,6 +32,7 @@ public class ReviewController {
         return ResponseEntity.ok().body(reviews);
     }
 
+    @ApiOperation(value = "리뷰 등록", notes = "사용자(일반)가 체육관 ID에 해당하는 리뷰를 등록한다.")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/{stadiumId}/reviews")
     public ResponseEntity<?> createReview(
@@ -41,6 +45,7 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(review);
     }
 
+    @ApiOperation(value = "리뷰 삭제", notes = "사용자(일반)가 등록한 리뷰를 삭제한다.")
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/{stadiumId}/reviews/{reviewId}")
     public ResponseEntity<?> deleteReview(
@@ -53,6 +58,7 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiOperation(value = "리뷰 수정", notes = "사용자(일반)가 등록한 리뷰를 수정한다.")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PatchMapping("/{stadiumId}/reviews/{reviewId}")
     public ResponseEntity<?> updateReview(

--- a/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
+++ b/src/main/java/com/minwonhaeso/esc/review/controller/ReviewController.java
@@ -23,6 +23,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @ApiOperation(value = "리뷰 조회", notes = "사용자(일반&매니저)가 리뷰를 조회한다.")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/{stadiumId}/reviews")
     public ResponseEntity<?> getAllReviews(
             @PathVariable Long stadiumId,

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -14,7 +14,7 @@ public class ReviewDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @ApiModel(value = "체육관 생성 Request Body")
+    @ApiModel(value = "리뷰 Request Body")
     public static class Request {
         private Double star;
         private String comment;
@@ -24,7 +24,7 @@ public class ReviewDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @ApiModel(value = "체육관 생성 Request Body")
+    @ApiModel(value = "리뷰 Response Body")
     public static class Response {
         private Long id;
         private Double star;

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -6,13 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 public class ReviewDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class Request {
-        private float star;
+        private Double star;
         private String comment;
     }
 
@@ -21,13 +23,19 @@ public class ReviewDto {
     @AllArgsConstructor
     @Builder
     public static class Response {
-        private float star;
+        private Long id;
+        private Double star;
         private String comment;
+        private String nickname;
+        private LocalDate createdAt;
 
         public static ReviewDto.Response fromEntity(Review review) {
             return Response.builder()
+                    .id(review.getId())
                     .star(review.getStar())
                     .comment(review.getComment())
+                    .nickname(review.getMember().getNickname())
+                    .createdAt(review.getCreatedAt())
                     .build();
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.review.model.dto;
 
 import com.minwonhaeso.esc.review.model.entity.Review;
+import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class ReviewDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @ApiModel(value = "체육관 생성 Request Body")
     public static class Request {
         private Double star;
         private String comment;
@@ -22,6 +24,7 @@ public class ReviewDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @ApiModel(value = "체육관 생성 Request Body")
     public static class Response {
         private Long id;
         private Double star;

--- a/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
@@ -5,11 +5,10 @@ import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.sun.istack.NotNull;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -33,16 +32,13 @@ public class Review {
     private Member member;
 
     @NotNull
-    private float star;
+    private Double star;
     private String comment;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
-    public void update(float star, String comment) {
+    public void update(Double star, String comment) {
         this.star = star;
         this.comment = comment;
     }

--- a/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.minwonhaeso.esc.review.repository;
 
+import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.entity.Review;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import org.springframework.data.domain.Page;
@@ -7,10 +8,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Override
     Page<Review> findAll(Pageable pageable);
     Page<Review> findAllByStadium(Stadium stadium, Pageable pageable);
+    Optional<Review> findByIdAndStadiumAndMember(Long reviewId, Stadium stadium, Member member);
+    long countAllByMember(Member member);
 }

--- a/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/review/repository/ReviewRepository.java
@@ -17,5 +17,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findAll(Pageable pageable);
     Page<Review> findAllByStadium(Stadium stadium, Pageable pageable);
     Optional<Review> findByIdAndStadiumAndMember(Long reviewId, Stadium stadium, Member member);
-    long countAllByMember(Member member);
+    Long countAllByMemberAndStadium(Member member, Stadium stadium);
 }

--- a/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
+++ b/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
@@ -1,30 +1,99 @@
 package com.minwonhaeso.esc.review.service;
 
+import com.minwonhaeso.esc.error.exception.ReviewException;
 import com.minwonhaeso.esc.error.exception.StadiumException;
-import com.minwonhaeso.esc.error.type.StadiumErrorCode;
+import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.dto.ReviewDto;
+import com.minwonhaeso.esc.review.model.entity.Review;
 import com.minwonhaeso.esc.review.repository.ReviewRepository;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.minwonhaeso.esc.error.type.ReviewErrorCode.*;
+import static com.minwonhaeso.esc.error.type.StadiumErrorCode.StadiumNotFound;
+
 @RequiredArgsConstructor
+@Slf4j
 @Service
 public class ReviewService {
     private final ReviewRepository reviewRepository;
 
     private final StadiumRepository stadiumRepository;
+    private final StadiumReservationRepository stadiumReservationRepository;
 
     @Transactional(readOnly = true)
     public Page<ReviewDto.Response> getAllReviewsByStadium(Long stadiumId, Pageable pageable) {
-        Stadium stadium = stadiumRepository.findById(stadiumId)
-                .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
-
+        Stadium stadium = findByStadiumId(stadiumId);
         return reviewRepository.findAllByStadium(stadium, pageable).map(ReviewDto.Response::fromEntity);
+    }
+
+    @Transactional
+    public ReviewDto.Response createReview(ReviewDto.Request request, Member member, Long stadiumId) {
+        Stadium stadium = findByStadiumId(stadiumId);
+
+        long reservationCount = stadiumReservationRepository.countAllByMember(member);
+        long reviewCount = reviewRepository.countAllByMember(member);
+
+//        if(reservationCount == 0) {
+//            throw new ReviewException(NoReservationForReview);
+//        } else if (reservationCount <= reviewCount) {
+//            throw new ReviewException(ReviewCountOverReservation);
+//        }
+
+        Review review = Review.builder()
+                .star(request.getStar())
+                .comment(request.getComment())
+                .stadium(stadium)
+                .member(member)
+                .build();
+
+        reviewRepository.save(review);
+        log.info("회원 번호 [ " + member.getMemberId() + " ] -  리뷰를 작성하였습니다.");
+
+        return ReviewDto.Response.fromEntity(review);
+    }
+
+    public void deleteReview(Member member, Long stadiumId, Long reviewId) {
+        Stadium stadium = findByStadiumId(stadiumId);
+        Review review = findByIdAndStadiumAndMember(reviewId, stadium, member);
+
+        if (review.getMember().getMemberId() != member.getMemberId()) {
+            throw new ReviewException(UnAuthorizedAccess);
+        }
+
+        reviewRepository.delete(review);
+        log.info("회원 번호 [ " + member.getMemberId() + " ] -  리뷰를 삭제하였습니다.");
+    }
+
+    public ReviewDto.Response updateReview(ReviewDto.Request request, Member member, Long stadiumId, Long reviewId) {
+        Stadium stadium = findByStadiumId(stadiumId);
+        Review review = findByIdAndStadiumAndMember(reviewId, stadium, member);
+
+        if (review.getMember().getMemberId() != member.getMemberId()) {
+            throw new ReviewException(UnAuthorizedAccess);
+        }
+
+        review.update(request.getStar(), request.getComment());
+        reviewRepository.save(review);
+        log.info("회원 번호 [ " + member.getMemberId() + " ] -  리뷰를 수정하였습니다.");
+
+        return ReviewDto.Response.fromEntity(review);
+    }
+
+    private Stadium findByStadiumId(Long stadiumId) {
+        return stadiumRepository.findById(stadiumId).orElseThrow(() -> new StadiumException(StadiumNotFound));
+    }
+
+    private Review findByIdAndStadiumAndMember(Long reviewId, Stadium stadium, Member member) {
+        return reviewRepository.findByIdAndStadiumAndMember(reviewId, stadium, member)
+                .orElseThrow(() -> new ReviewException(ReviewNotFound));
     }
 
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
@@ -2,6 +2,7 @@ package com.minwonhaeso.esc.stadium.repository;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
+import org.elasticsearch.monitor.os.OsStats;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ import java.time.LocalDateTime;
 public interface StadiumReservationRepository extends JpaRepository<StadiumReservation, Long> {
     Page<StadiumReservation> findAllByMemberAndStatusAndStartDateAfter(
             Member member, String status, LocalDateTime today, Pageable pageable);
+
+    long countAllByMember(Member member);
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
@@ -1,11 +1,14 @@
 package com.minwonhaeso.esc.stadium.repository;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
+import com.minwonhaeso.esc.stadium.model.type.StadiumReservationStatus;
 import org.elasticsearch.monitor.os.OsStats;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -15,5 +18,5 @@ public interface StadiumReservationRepository extends JpaRepository<StadiumReser
     Page<StadiumReservation> findAllByMemberAndStatusAndStartDateAfter(
             Member member, String status, LocalDateTime today, Pageable pageable);
 
-    long countAllByMember(Member member);
+    Long countAllByMemberAndStadiumAndStatusIs(Member member, Stadium stadium, StadiumReservationStatus status);
 }


### PR DESCRIPTION
### Background
---
- 리뷰 등록, 삭제, 수정에 대한 API 작업이 필요했음

### Change
---
- [x]  조회의 경우, 일반 사용자 매니저 둘 다 사용 가능
- [x]  이외의 등록, 삭제, 수정은 일반 사용자 권한으로 설정

### Test
---
- Postman을 이용해서 CRUD 테스트 완료

### To-Do
---
- 리뷰 권한 확인 고도화
- SSE 적용

### Discuss
---
- 일단 테스트를 위해 기본 로직으로 리뷰 작성 횟수는 예약 횟수에 맞춰 작성할 수 있도록 했습니다. 
- 추후, 사용 횟수(예약 상태 - Executed) 확인과 더불어 사용 체육관 검증 과정도 추가하겠습니다.
