### PR TITLE
Feat : 찜하기(Like) 셋팅

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StadiumErrorCode {
     StadiumNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 정보가 존재하지 않습니다."),
-    UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
+    UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+    LikeRequestAlreadyMatched(HttpStatus.BAD_REQUEST, "요청 타입이 이미 적용되어 있습니다.");
 
     private final HttpStatus statusCode;
     private final String errorMessage;

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -55,7 +55,7 @@ public class MemberController {
      * 메일 인증
      **/
     @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
-    @GetMapping("/email-authentication")
+    @PostMapping("/email-authentication")
     public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
         Map<String, String> result = memberService.emailAuthentication(key);
         return ResponseEntity.ok(result);

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
@@ -12,7 +12,9 @@ public class InfoDto {
     @AllArgsConstructor
     public static class Response{
         private String nickname;
+        private String name;
         private String email;
         private String imgUrl;
+        private String password;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/entity/Member.java
@@ -5,11 +5,14 @@ import com.minwonhaeso.esc.member.model.type.MemberRole;
 import com.minwonhaeso.esc.member.model.type.MemberStatus;
 import com.minwonhaeso.esc.member.model.type.MemberType;
 import com.minwonhaeso.esc.security.oauth2.type.ProviderType;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import com.sun.istack.NotNull;
 import io.jsonwebtoken.Claims;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -53,6 +56,10 @@ public class Member {
     private ProviderType providerType; // 소셜 타입
 
     private String providerId;
+
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "likes")
+    private List<StadiumLike> likes = new ArrayList<>();
 
 
     public static Member of(SignDto.Request signDto) {

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -143,6 +143,8 @@ public class MemberService {
                 .nickname(member.getNickname())
                 .email(member.getEmail())
                 .imgUrl(member.getImgUrl())
+                .name(member.getName())
+                .password(member.getPassword())
                 .build();
     }
 
@@ -185,7 +187,7 @@ public class MemberService {
         MemberEmail memberEmail = MemberEmail.createEmailAuthKey(email, uuid, emailExpiredTime);
         String subject = "[ESC] 비밀번호 변경 안내";
         String content = "<p>비밀번호 변경 코드: " + uuid + "</p>";
-        mailService.sendMail(email, subject, content);
+//        mailService.sendMail(email, subject, content);
         memberEmailRepository.save(memberEmail);
         return uuid;
     }

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -23,7 +23,7 @@ public class StadiumLikeController {
     private final StadiumLikeService stadiumLikeService;
     @PostMapping("/{stadiumId}/likes/{type}")
     public ResponseEntity<?> likes(@PathVariable(value = "stadiumId") Long stadiumId,
-                                   @PathVariable("type") String type,
+                                   @PathVariable(value = "type") String type,
                                    @AuthenticationPrincipal PrincipalDetail principalDetail){
         Member member = principalDetail.getMember();
         Map<String,String> result =  stadiumLikeService.likes(stadiumId,type,member);

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -1,0 +1,33 @@
+package com.minwonhaeso.esc.stadium.controller;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
+import com.minwonhaeso.esc.stadium.service.StadiumLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RestController
+@PreAuthorize("hasRole('USER')")
+@RequestMapping("/stadiums")
+public class StadiumLikeController {
+
+    private final StadiumLikeService stadiumLikeService;
+    @PostMapping("/{stadiumId}/likes/{type}")
+    public ResponseEntity<?> likes(@PathVariable(value = "stadiumId") Long stadiumId,
+                                   @PathVariable("type") String type,
+                                   @AuthenticationPrincipal PrincipalDetail principalDetail){
+        Member member = principalDetail.getMember();
+        Map<String,String> result =  stadiumLikeService.likes(stadiumId,type,member);
+        return ResponseEntity.ok(result);
+    }
+}
+

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -95,6 +95,9 @@ public class Stadium {
     @OneToMany(mappedBy = "stadium")
     private List<StadiumTag> tags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "stadium")
+    private List<StadiumLike> likes = new ArrayList<>();
+
 //    @OneToMany(mappedBy = "stadium")
 //    @Column(name = "reviews")
 //    private List<Review> reviews;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -95,8 +95,6 @@ public class Stadium {
     @OneToMany(mappedBy = "stadium")
     private List<StadiumTag> tags = new ArrayList<>();
 
-    @OneToMany(mappedBy = "stadium")
-    private List<StadiumLike> likes = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "stadium")
 //    @Column(name = "reviews")

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumLike.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumLike.java
@@ -1,0 +1,34 @@
+package com.minwonhaeso.esc.stadium.model.entity;
+
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "stadium_like")
+@Entity
+public class StadiumLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "memberId")
+    @ManyToOne
+    private Member member;
+
+    @JoinColumn(name = "stadiumId")
+    @ManyToOne
+    private Stadium stadium;
+
+    public StadiumLike(Member member, Stadium stadium) {
+        this.member = member;
+        this.stadium = stadium;
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
@@ -1,0 +1,14 @@
+package com.minwonhaeso.esc.stadium.repository;
+
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StadiumLikeRepository extends JpaRepository<StadiumLike, Long> {
+    Optional<StadiumLike> findByMemberAndStadium(Member member, Stadium stadium);
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
@@ -6,9 +6,11 @@ import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.transaction.Transactional;
 import java.util.Optional;
 
 @Repository
 public interface StadiumLikeRepository extends JpaRepository<StadiumLike, Long> {
     Optional<StadiumLike> findByMemberAndStadium(Member member, Stadium stadium);
+
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -25,8 +25,9 @@ public class StadiumLikeService {
                 .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
         Optional<StadiumLike> optionalLike = stadiumLikeRepository.findByMemberAndStadium(member, stadium);
         likeCD(onOff, member, stadium, optionalLike);
-
-        return (Map<String, String>) new HashMap<>().put("successMessage","찜하기 반영 성공");
+        Map<String,String> map = new HashMap<>();
+        map.put("successMessage","찜하기 반영 성공");
+        return map;
     }
 
     private void likeCD(String onOff, Member member, Stadium stadium, Optional<StadiumLike> optionalLike) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -1,0 +1,48 @@
+package com.minwonhaeso.esc.stadium.service;
+
+import com.minwonhaeso.esc.error.exception.StadiumException;
+import com.minwonhaeso.esc.error.type.StadiumErrorCode;
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
+import com.minwonhaeso.esc.stadium.repository.StadiumLikeRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumLikeService {
+    private final StadiumLikeRepository stadiumLikeRepository;
+    private final StadiumRepository stadiumRepository;
+
+    public Map<String, String> likes(Long stadiumId, String onOff, Member member) {
+        Stadium stadium = stadiumRepository.findById(stadiumId)
+                .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
+        Optional<StadiumLike> optionalLike = stadiumLikeRepository.findByMemberAndStadium(member, stadium);
+        likeCD(onOff, member, stadium, optionalLike);
+
+        return (Map<String, String>) new HashMap<>().put("successMessage","찜하기 반영 성공");
+    }
+
+    private void likeCD(String onOff, Member member, Stadium stadium, Optional<StadiumLike> optionalLike) {
+        if (onOff.equals("ON")) {
+            if (optionalLike.isEmpty()) {
+                stadiumLikeRepository.save(new StadiumLike(member, stadium));
+            } else {
+                throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
+            }
+        }
+        if (onOff.equals("OFF")) {
+            if (optionalLike.isPresent()) {
+                stadiumLikeRepository.delete(optionalLike.get());
+            } else {
+                throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
+            }
+        }
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -20,25 +20,25 @@ public class StadiumLikeService {
     private final StadiumLikeRepository stadiumLikeRepository;
     private final StadiumRepository stadiumRepository;
 
-    public Map<String, String> likes(Long stadiumId, String onOff, Member member) {
+    public Map<String, String> likes(Long stadiumId, String likeDislike, Member member) {
         Stadium stadium = stadiumRepository.findById(stadiumId)
                 .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
         Optional<StadiumLike> optionalLike = stadiumLikeRepository.findByMemberAndStadium(member, stadium);
-        likeCD(onOff, member, stadium, optionalLike);
+        likeCD(likeDislike, member, stadium, optionalLike);
         Map<String,String> map = new HashMap<>();
         map.put("successMessage","찜하기 반영 성공");
         return map;
     }
 
-    private void likeCD(String onOff, Member member, Stadium stadium, Optional<StadiumLike> optionalLike) {
-        if (onOff.equals("ON")) {
+    private void likeCD(String likeDislike, Member member, Stadium stadium, Optional<StadiumLike> optionalLike) {
+        if (likeDislike.equals("ON")) {
             if (optionalLike.isEmpty()) {
                 stadiumLikeRepository.save(new StadiumLike(member, stadium));
             } else {
                 throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
             }
         }
-        if (onOff.equals("OFF")) {
+        if (likeDislike.equals("OFF")) {
             if (optionalLike.isPresent()) {
                 stadiumLikeRepository.delete(optionalLike.get());
             } else {


### PR DESCRIPTION
### Background
---
기존 Pr에서 Review 관련해서 Merge한 내용이 반영되어있지 않아 conflict이 발생함.
회원상세정보 API Response에서 name과 password를 반환하지 않았다.

### Change
---
* 찜하기 관련 기본적인 클래스 생성
* Member와 Stadium이랑 1대 다 매핑, (Member는 양방향 Stadium은 단방향)
* StadiumErrorCode에 Like관련 ErrorCode 하나 추가
* 찜하기 ON/OFF를 하나의 API로 받는 방식으로 개발
* Merge Conflict 해결
* 회원상세정보 API Response name & password 추가
* 이메일 인증 API Post로 변경

### Test
---
Postman을 통한 Test 완료

### Discuss
---
현재 다음 구현 예정인 API는 나의 찜하기 목록에 사용될 API입니다.

