### PR TITLE
Feat : 찜하기 목록 조회  구현

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController {
      **/
     @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
     @PostMapping("/email-authentication")
-    public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
+    public ResponseEntity<?> emailAuthentication(@RequestBody String key) {
         Map<String, String> result = memberService.emailAuthentication(key);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -153,7 +153,9 @@ public class MemberService {
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
         if (request.getNickname() != null) {
             member.setNickname(request.getNickname());
-        } else if (request.getImgUrl() != null) {
+        }
+
+        if (request.getImgUrl() != null) {
             member.setImgUrl(request.getImgUrl());
         }
         memberRepository.save(member);

--- a/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtExpirationEnums.java
+++ b/src/main/java/com/minwonhaeso/esc/security/auth/jwt/JwtExpirationEnums.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum JwtExpirationEnums {
 
-    ACCESS_TOKEN_EXPIRATION_TIME("JWT 만료 시간 / 30분", 1000L * 60 * 60 * 24 * 7),
+    ACCESS_TOKEN_EXPIRATION_TIME("JWT 만료 시간 / 60분", 1000L * 60 * 60),
     REFRESH_TOKEN_EXPIRATION_TIME("Refresh 토큰 만료 시간 / 7일", 1000L * 60 * 60 * 24 * 7),
     REISSUE_EXPIRATION_TIME("Refresh 토큰 만료 시간 / 3일", 1000L * 60 * 60 * 24 * 3);
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -4,6 +4,7 @@ import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumLikeResponseDto;
 import com.minwonhaeso.esc.stadium.service.StadiumLikeService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +23,7 @@ public class StadiumLikeController {
 
     private final StadiumLikeService stadiumLikeService;
 
+    @ApiOperation(value = "찜하기 or 취소", notes = "ON 혹은 OFF type을 받아 찜하기와 찜하기 취소 작업을 진행합니다.")
     @PostMapping("/{stadiumId}/likes/{type}")
     public ResponseEntity<?> likes(@PathVariable(value = "stadiumId") Long stadiumId,
                                    @PathVariable(value = "type") String type,
@@ -31,6 +33,7 @@ public class StadiumLikeController {
         return ResponseEntity.ok(result);
     }
 
+    @ApiOperation(value = "찜하기 리스트", notes = "접속한 유저가 찜한 체육관 리스트를 보여줍니다.")
     @GetMapping("/likelist")
     public ResponseEntity<?> likeList(@AuthenticationPrincipal PrincipalDetail principalDetail,
                                       Pageable pageable){

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -2,15 +2,15 @@ package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumLikeResponseDto;
 import com.minwonhaeso.esc.stadium.service.StadiumLikeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -21,6 +21,7 @@ import java.util.Map;
 public class StadiumLikeController {
 
     private final StadiumLikeService stadiumLikeService;
+
     @PostMapping("/{stadiumId}/likes/{type}")
     public ResponseEntity<?> likes(@PathVariable(value = "stadiumId") Long stadiumId,
                                    @PathVariable(value = "type") String type,
@@ -29,5 +30,14 @@ public class StadiumLikeController {
         Map<String,String> result =  stadiumLikeService.likes(stadiumId,type,member);
         return ResponseEntity.ok(result);
     }
+
+    @GetMapping("/likelist")
+    public ResponseEntity<?> likeList(@AuthenticationPrincipal PrincipalDetail principalDetail,
+                                      Pageable pageable){
+        Member member = principalDetail.getMember();
+        Page<StadiumLikeResponseDto> likes = stadiumLikeService.likeList(member,pageable);
+        return ResponseEntity.ok(likes);
+    }
+
 }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
@@ -1,0 +1,31 @@
+package com.minwonhaeso.esc.stadium.model.dto;
+
+import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StadiumLikeResponseDto {
+    private Long id;
+
+    private String name;
+
+    private String address;
+
+    private Double starAvg;
+
+
+    public static StadiumLikeResponseDto fromEntity(StadiumLike stadiumLike) {
+        return StadiumLikeResponseDto.builder()
+                .id(stadiumLike.getId())
+                .name(stadiumLike.getStadium().getName())
+                .address(stadiumLike.getStadium().getAddress())
+                .starAvg(stadiumLike.getStadium().getStarAvg())
+                .build();
+    }
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumLike.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumLike.java
@@ -3,8 +3,6 @@ package com.minwonhaeso.esc.stadium.model.entity;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import javax.persistence.*;
 
 @Getter

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumLikeRepository.java
@@ -3,14 +3,16 @@ package com.minwonhaeso.esc.stadium.repository;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import javax.transaction.Transactional;
 import java.util.Optional;
 
 @Repository
 public interface StadiumLikeRepository extends JpaRepository<StadiumLike, Long> {
     Optional<StadiumLike> findByMemberAndStadium(Member member, Stadium stadium);
 
+    Page<StadiumLike> findByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -3,12 +3,16 @@ package com.minwonhaeso.esc.stadium.service;
 import com.minwonhaeso.esc.error.exception.StadiumException;
 import com.minwonhaeso.esc.error.type.StadiumErrorCode;
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumLikeResponseDto;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import com.minwonhaeso.esc.stadium.repository.StadiumLikeRepository;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,5 +49,9 @@ public class StadiumLikeService {
                 throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
             }
         }
+    }
+    @Transactional(readOnly = true)
+    public Page<StadiumLikeResponseDto> likeList(Member member, Pageable pageable) {
+        return stadiumLikeRepository.findByMember(member,pageable).map(StadiumLikeResponseDto::fromEntity);
     }
 }


### PR DESCRIPTION
### Background
---
* 이메일 인증 API Request 방식이 param 이었다.

### Change
---
* 이메일 인증 API 방식 param -> body로 변경
* 찜한 체육관 리스트를 받아오는 API 추가
* Swagger API 설명 추가
* 회원정보 수정 if elseif 구문 if if로 변경
* JWT AccessToken 유효기간 60분으로 변경
* 메일 인증 Api Request 방식 param에서 body로 변경

### Test
---
* Postman을 통한 요청 테스트


