### PR TITLE
Fix : UI Test 관련 오류 수정 

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
@@ -14,7 +14,10 @@ public enum StadiumErrorCode {
     UnAuthorizedAccess(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
     AlreadyReservedTime(HttpStatus.CONFLICT, "이미 예약이 완료되거나 진행중인 시간대입니다."),
     LikeRequestAlreadyMatched(HttpStatus.BAD_REQUEST, "요청 타입이 이미 적용되어 있습니다."),
-    TimeFormatNotAccepted(HttpStatus.BAD_REQUEST, "시간 형식이 옳바르지 않습니다.");
+    TimeFormatNotAccepted(HttpStatus.BAD_REQUEST, "시간 형식이 옳바르지 않습니다."),
+    StadiumImgNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 이미지 정보가 존재하지 않습니다."),
+    StadiumTagNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 종목 정보가 존재하지 않습니다."),
+    StadiumItemNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 대여 용품 정보가 존재하지 않습니다.");
 
     private final HttpStatus statusCode;
     private final String errorMessage;

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberController.java
@@ -56,7 +56,8 @@ public class MemberController {
      **/
     @ApiOperation(value = "메일 인증", notes = "메일 인증 코드가 맞는지 확인합니다.")
     @PostMapping("/email-authentication")
-    public ResponseEntity<?> emailAuthentication(@RequestParam String key) {
+    public ResponseEntity<?> emailAuthentication(@RequestBody Map<String, String> response) {
+        String key = response.get("key");
         Map<String, String> result = memberService.emailAuthentication(key);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -63,8 +63,9 @@ public class MemberProfileController {
      * 비밀번호 변경 메일 인증코드 확인
      **/
     @ApiOperation(value = "인증코드 확인(비밀번호 변경)", notes = "비밀번호 변경을 위한 메일 인증 코드 일치 여부를 확인합니다.")
-    @GetMapping("/password")
-    public ResponseEntity<?> changePasswordMailAuth(@RequestParam String key) {
+    @PostMapping("/password/config")
+    public ResponseEntity<?> changePasswordMailAuth(@RequestBody Map<String, String> response) {
+        String key = response.get("key");
         Map<String, String> result = memberService.changePasswordMailAuth(key);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -153,7 +153,9 @@ public class MemberService {
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
         if (request.getNickname() != null) {
             member.setNickname(request.getNickname());
-        } else if (request.getImgUrl() != null) {
+        }
+
+        if (request.getImgUrl() != null) {
             member.setImgUrl(request.getImgUrl());
         }
         memberRepository.save(member);
@@ -187,7 +189,7 @@ public class MemberService {
         MemberEmail memberEmail = MemberEmail.createEmailAuthKey(email, uuid, emailExpiredTime);
         String subject = "[ESC] 비밀번호 변경 안내";
         String content = "<p>비밀번호 변경 코드: " + uuid + "</p>";
-//        mailService.sendMail(email, subject, content);
+        mailService.sendMail(email, subject, content);
         memberEmailRepository.save(memberEmail);
         return uuid;
     }

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class ReviewDto {
     @Getter
@@ -27,18 +28,20 @@ public class ReviewDto {
     @ApiModel(value = "리뷰 Response Body")
     public static class Response {
         private Long id;
+        private Long memberId;
         private Double star;
         private String comment;
         private String nickname;
-        private LocalDate createdAt;
+        private String createdAt;
 
         public static ReviewDto.Response fromEntity(Review review) {
             return Response.builder()
                     .id(review.getId())
+                    .memberId(review.getMember().getMemberId())
                     .star(review.getStar())
                     .comment(review.getComment())
                     .nickname(review.getMember().getNickname())
-                    .createdAt(review.getCreatedAt())
+                    .createdAt(review.getCreatedAt().toString())
                     .build();
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.stadium.controller;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.stadium.service.StadiumLikeService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,13 +22,13 @@ import java.util.Map;
 public class StadiumLikeController {
 
     private final StadiumLikeService stadiumLikeService;
-    @PostMapping("/{stadiumId}/likes/{type}")
+
+    @ApiOperation(value = "찜하기 or 취소", notes = "ON 혹은 OFF type을 받아 찜하기와 찜하기 취소 작업을 진행합니다.")
+    @PostMapping("/{stadiumId}/likes")
     public ResponseEntity<?> likes(@PathVariable(value = "stadiumId") Long stadiumId,
-                                   @PathVariable(value = "type") String type,
                                    @AuthenticationPrincipal PrincipalDetail principalDetail){
         Member member = principalDetail.getMember();
-        Map<String,String> result =  stadiumLikeService.likes(stadiumId,type,member);
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(stadiumLikeService.likes(stadiumId, member));
     }
 }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -60,10 +60,10 @@ public class StadiumManagerController {
     public ResponseEntity<?> addStadiumImgByManager(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
             @PathVariable Long stadiumId,
-            @RequestBody StadiumImgDto.AddImgRequest request
+            @RequestBody StadiumImgDto request
     ) {
         Member member = principalDetail.getMember();
-        StadiumImgDto.CreateImgResponse img = stadiumService.addStadiumImg(member, stadiumId, request.getImgUrl());
+        StadiumImgDto img = stadiumService.addStadiumImg(member, stadiumId, request.getImgUrl());
         return ResponseEntity.ok().body(img);
     }
 
@@ -72,10 +72,10 @@ public class StadiumManagerController {
     public ResponseEntity<?> addStadiumTagByManager(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
             @PathVariable Long stadiumId,
-            @RequestBody StadiumTagDto.AddTagRequest request
+            @RequestBody StadiumTagDto request
     ) {
         Member member = principalDetail.getMember();
-        StadiumTagDto.AddTagResponse tag = stadiumService.addStadiumTag(member, stadiumId, request.getTagName());
+        StadiumTagDto tag = stadiumService.addStadiumTag(member, stadiumId, request.getTagName());
         return ResponseEntity.ok().body(tag);
     }
 
@@ -94,7 +94,7 @@ public class StadiumManagerController {
     public ResponseEntity<?> deleteStadiumImgByManager(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
             @PathVariable Long stadiumId,
-            @RequestBody StadiumImgDto.DeleteImgRequest request
+            @RequestBody StadiumImgDto request
     ) {
         Member member = principalDetail.getMember();
         stadiumService.deleteStadiumImg(member, stadiumId, request.getImgUrl());
@@ -106,7 +106,7 @@ public class StadiumManagerController {
     public ResponseEntity<?> deleteStadiumTagByManager(
             @AuthenticationPrincipal PrincipalDetail principalDetail,
             @PathVariable Long stadiumId,
-            @RequestBody StadiumTagDto.DeleteTagRequest request
+            @RequestBody StadiumTagDto request
     ) {
         Member member = principalDetail.getMember();
         stadiumService.deleteStadiumTag(member, stadiumId, request.getTagName());

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumManagerController.java
@@ -51,7 +51,7 @@ public class StadiumManagerController {
             @RequestBody StadiumDto.UpdateStadiumRequest request
     ) {
         Member member = principalDetail.getMember();
-        StadiumResponseDto stadium = stadiumService.updateStadiumInfo(member, stadiumId, request);
+        StadiumInfoResponseDto stadium = stadiumService.updateStadiumInfo(member, stadiumId, request);
         return ResponseEntity.ok().body(stadium);
     }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
@@ -1,6 +1,8 @@
 package com.minwonhaeso.esc.stadium.controller;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.notification.model.type.NotificationType;
+import com.minwonhaeso.esc.notification.service.NotificationService;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto.CreateReservationRequest;
@@ -25,6 +27,7 @@ import java.time.LocalDate;
 @RequestMapping("/stadiums")
 public class StadiumReservationController {
     private final StadiumReservationService stadiumReservationService;
+    private final NotificationService notificationService;
 
     @ApiOperation(value = "내 예약 목록", notes = "내가 예약한 목록 모두 조회")
     @GetMapping("/reservations")
@@ -87,6 +90,9 @@ public class StadiumReservationController {
         Member member = principalDetail.getMember();
         ReservationInfoResponse reservationInfo =
                 stadiumReservationService.createReservation(member, stadiumId, request);
+        notificationService.createNotification(
+                NotificationType.RESERVATION, stadiumId, reservationInfo.getId(),
+                "새로운 예약이 있습니다.", member);
         return ResponseEntity.status(HttpStatus.CREATED).body(reservationInfo);
     }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
@@ -67,7 +67,6 @@ public class StadiumDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @ApiModel(value = "체육관 정보 수정 Request Body")
-    @ToString
     public static class UpdateStadiumRequest {
         private String name;
         private String phone;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
@@ -67,6 +67,7 @@ public class StadiumDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @ApiModel(value = "체육관 정보 수정 Request Body")
+    @ToString
     public static class UpdateStadiumRequest {
         private String name;
         private String phone;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
@@ -37,7 +37,7 @@ public class StadiumDto {
         private String closeTime;
 
         @Builder.Default
-        private List<StadiumImgDto.CreateImgRequest> imgs = new ArrayList<>();
+        private List<StadiumImgDto> imgs = new ArrayList<>();
 
         @Builder.Default
         private List<String> tags = new ArrayList<>();
@@ -77,5 +77,14 @@ public class StadiumDto {
         private Integer holidayPricePerHalfHour;
         private String openTime;
         private String closeTime;
+
+        @Builder.Default
+        private List<StadiumImgDto> imgs = new ArrayList<>();
+
+        @Builder.Default
+        private List<StadiumTagDto> tags = new ArrayList<>();
+
+        @Builder.Default
+        private List<StadiumItemDto.CreateItemRequest> items = new ArrayList<>();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumDto.java
@@ -52,11 +52,11 @@ public class StadiumDto {
     @Builder
     @ApiModel(value = "체육관 생성 성공 Response Body")
     public static class CreateStadiumResponse {
-        private StadiumResponseDto stadium;
+        private StadiumInfoResponseDto stadium;
 
         public static CreateStadiumResponse fromEntity(Stadium stadium) {
             return CreateStadiumResponse.builder()
-                    .stadium(StadiumResponseDto.fromEntity(stadium))
+                    .stadium(StadiumInfoResponseDto.fromEntity(stadium))
                     .build();
         }
     }
@@ -82,9 +82,9 @@ public class StadiumDto {
         private List<StadiumImgDto> imgs = new ArrayList<>();
 
         @Builder.Default
-        private List<StadiumTagDto> tags = new ArrayList<>();
+        private List<String> tags = new ArrayList<>();
 
         @Builder.Default
-        private List<StadiumItemDto.CreateItemRequest> items = new ArrayList<>();
+        private List<StadiumItemDto.UpdateItemRequest> rentalItems = new ArrayList<>();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumImgDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumImgDto.java
@@ -1,10 +1,14 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
 import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 @ApiModel(value = "체육관 이미지 Body")
 public class StadiumImgDto {

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumImgDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumImgDto.java
@@ -4,41 +4,11 @@ import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
+@Data
+@Builder
+@ApiModel(value = "체육관 이미지 Body")
 public class StadiumImgDto {
-    @Data
-    @Builder
-    @ApiModel(value = "체육관 이미지 조회 Response Body")
-    public static class ImgResponse {
-        private String publicId;
-        private String imgUrl;
-    }
-
-    @Data
-    @ApiModel(value = "체육관 이미지 추가 Request Body")
-    public static class CreateImgRequest {
-        private String publicId;
-        private String imgUrl;
-    }
-
-    @Data
-    @Builder
-    @ApiModel(value = "체육관 이미지 Response Body")
-    public static class CreateImgResponse {
-        private String publicId;
-        private String imgUrl;
-    }
-
-    @Data
-    @ApiModel(value = "체육관 이미지 추가 Request Body")
-    public static class AddImgRequest {
-        private String publicId;
-        private String imgUrl;
-    }
-
-    @Data
-    @ApiModel(value = "체육관 이미지 삭제 Request Body")
-    public static class DeleteImgRequest {
-        private String publicId;
-        private String imgUrl;
-    }
+    private Long id;
+    private String publicId;
+    private String imgUrl;
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -5,10 +5,7 @@ import com.minwonhaeso.esc.stadium.model.entity.StadiumTag;
 import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,9 +39,6 @@ public class StadiumInfoResponseDto {
 
     @ApiModelProperty(value = "평점", example = "4.5")
     private Double starAvg;
-
-    @ApiModelProperty(value = "찜하기 수", example = "8")
-    private Integer likes;
 
     @ApiModelProperty(value = "평일 30분당 가격", example = "20000")
     private Integer weekdayPricePerHalfHour;
@@ -85,14 +79,12 @@ public class StadiumInfoResponseDto {
                         null :
                         stadium.getImgs().stream().map(img ->
                                 StadiumImgDto.builder()
+                                        .id(img.getId())
                                         .publicId(img.getImgId())
                                         .imgUrl(img.getImgUrl())
                                         .build())
                         .collect(Collectors.toList()))
                 .tags(stadium.getTags().stream().map(StadiumTag::getName).collect(Collectors.toList()))
-                // TODO: 찜하기 수 업데이트
-                // .likes(stadium.getLikes().size())
                 .build();
     }
-
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -34,6 +34,12 @@ public class StadiumInfoResponseDto {
     @ApiModelProperty(value = "주소", example = "경기도 수원시")
     private String address;
 
+    @ApiModelProperty(value = "상세 주소", example = "302호")
+    private String detailAddress;
+
+    @ApiModelProperty(value = "전화번호", example="01012345678")
+    private String phone;
+
     @ApiModelProperty(value = "평점", example = "4.5")
     private Double starAvg;
 
@@ -46,7 +52,7 @@ public class StadiumInfoResponseDto {
     @ApiModelProperty(value = "공휴일 30분당 가격", example = "30000")
     private Integer holidayPricePerHalfHour;
 
-    private List<StadiumItemDto.Response> items;
+    private List<StadiumItemDto.Response> rentalItems;
 
     @ApiModelProperty(value = "이미지", example = "['img_url1', 'img_url2', ...]")
     private List<StadiumImgDto.ImgResponse> imgs;
@@ -64,13 +70,15 @@ public class StadiumInfoResponseDto {
                 .name(stadium.getName())
                 .lat(stadium.getLat())
                 .lnt(stadium.getLnt())
+                .phone(stadium.getPhone())
                 .address(stadium.getAddress())
+                .detailAddress(stadium.getDetailAddress())
                 .starAvg(stadium.getStarAvg())
                 .weekdayPricePerHalfHour(stadium.getWeekdayPricePerHalfHour())
                 .holidayPricePerHalfHour(stadium.getHolidayPricePerHalfHour())
                 .openTime(ReservingTime.valueOf(stadium.getOpenTime()).getTime())
                 .closeTime(ReservingTime.valueOf(stadium.getCloseTime()).getTime())
-                .items(stadium.getRentalStadiumItems().stream()
+                .rentalItems(stadium.getRentalStadiumItems().stream()
                         .map(StadiumItemDto.Response::fromEntity)
                         .collect(Collectors.toList()))
                 .imgs(stadium.getImgs().isEmpty() ?

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -55,7 +55,7 @@ public class StadiumInfoResponseDto {
     private List<StadiumItemDto.Response> rentalItems;
 
     @ApiModelProperty(value = "이미지", example = "['img_url1', 'img_url2', ...]")
-    private List<StadiumImgDto.ImgResponse> imgs;
+    private List<StadiumImgDto> imgs;
     private List<String> tags;
 
     @ApiModelProperty(value = "오픈 시간", example = "HH:MM:SS")
@@ -84,7 +84,7 @@ public class StadiumInfoResponseDto {
                 .imgs(stadium.getImgs().isEmpty() ?
                         null :
                         stadium.getImgs().stream().map(img ->
-                                StadiumImgDto.ImgResponse.builder()
+                                StadiumImgDto.builder()
                                         .publicId(img.getImgId())
                                         .imgUrl(img.getImgUrl())
                                         .build())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumItemDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumItemDto.java
@@ -11,6 +11,7 @@ public class StadiumItemDto {
     @Data
     @ApiModel(value = "체육관 대여 용품 추가 Request Body")
     public static class CreateItemRequest {
+        private Long id;
         private String name;
         private String publicId;
         private String imgUrl;
@@ -21,31 +22,32 @@ public class StadiumItemDto {
     @Builder
     @ApiModel(value = "체육관 대여 용품 추가 성공 Response Body")
     public static class CreateItemResponse {
+        private Long id;
         private String name;
         private String publicId;
         private String imgUrl;
         private Integer price;
-        private boolean isAvailable;
     }
 
     @Data
     @ApiModel(value = "체육관 아이템 삭제 Request Body")
     public static class DeleteItemRequest {
-        private Long itemId;
+        private Long id;
     }
 
     @Data
     @Builder
     @ApiModel(value = "체육관 대여 용품 Response Body")
     public static class Response {
+        private Long id;
         private String name;
         private String publicId;
         private String imgUrl;
         private Integer price;
-        private boolean isAvailable;
 
         public static Response fromEntity(StadiumItem item) {
             return Response.builder()
+                    .id(item.getId())
                     .name(item.getName())
                     .publicId(item.getImgId())
                     .imgUrl(item.getImgUrl())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumItemDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumItemDto.java
@@ -2,15 +2,31 @@ package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.minwonhaeso.esc.stadium.model.entity.StadiumItem;
 import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
 public class StadiumItemDto {
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     @ApiModel(value = "체육관 대여 용품 추가 Request Body")
     public static class CreateItemRequest {
+        private String name;
+        private String publicId;
+        private String imgUrl;
+        private Integer price;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateItemRequest {
         private Long id;
         private String name;
         private String publicId;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeRequestDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeRequestDto.java
@@ -1,0 +1,10 @@
+package com.minwonhaeso.esc.stadium.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StadiumLikeRequestDto {
+    private boolean result;
+}

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
@@ -30,6 +30,7 @@ public class StadiumReservationDto {
     @Data
     @Builder
     public static class ReservationInfoResponse {
+        private Long id;
         private Long stadiumId;
         private String stadiumName;
         private LocalDate date;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumResponseDto.java
@@ -42,9 +42,6 @@ public class StadiumResponseDto {
     @ApiModelProperty(value = "휴일 가격", example = "30000")
     private Integer holidayPricePerHalfHour;
 
-    @ApiModelProperty(value = "찜하기 수", example = "8")
-    private Integer likes;
-
     @ApiModelProperty(value = "이미지", example = "['img_url1', 'img_url2', ...]")
     private String img; // TODO: 이미지주소 + public_id도 포함 필요
     private List<String> tags;
@@ -64,8 +61,6 @@ public class StadiumResponseDto {
                         null :
                         stadium.getImgs().get(0).getImgUrl())
                 .tags(stadium.getTags().stream().map(StadiumTag::getName).collect(Collectors.toList()))
-                // TODO: 찜하기 수 업데이트
-                // .likes(stadium.getLikes().size())
                 .build();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumTagDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumTagDto.java
@@ -1,11 +1,15 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
 import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @ApiModel(value = "체육관 종목(태그) Body")
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class StadiumTagDto {
     private Long id;

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumTagDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumTagDto.java
@@ -4,23 +4,10 @@ import io.swagger.annotations.ApiModel;
 import lombok.Builder;
 import lombok.Data;
 
+@ApiModel(value = "체육관 종목(태그) Body")
+@Data
+@Builder
 public class StadiumTagDto {
-    @Data
-    @ApiModel(value = "체육관 종목(태그) 추가 Request Body")
-    public static class AddTagRequest {
-        private String tagName;
-    }
-
-    @Data
-    @Builder
-    @ApiModel(value = "체육관 종목(태그) 추가 Response Body")
-    public static class AddTagResponse {
-        private String tagName;
-    }
-
-    @Data
-    @ApiModel(value = "체육관 종목(태그) 삭제 Request Body")
-    public static class DeleteTagRequest {
-        private String tagName;
-    }
+    private Long id;
+    private String tagName;
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -80,13 +80,9 @@ public class Stadium {
     @JoinColumn(name = "manager_id")
     private Member member;
 
-//    @OneToMany(mappedBy = "stadium")
-//    @Column(name = "reservations")
-//    private List<Reservation> reservations;
-
-//    @OneToMany(mappedBy = "stadium")
-//    @Column(name = "likes")
-//    private List<Like> likes;
+    @OneToMany(mappedBy = "stadium")
+    @Column(name = "reservations")
+    private List<StadiumReservation> reservations;
 
     @Builder.Default
     @OneToMany(mappedBy = "stadium")
@@ -153,40 +149,56 @@ public class Stadium {
     }
 
     public void setAll(StadiumDto.UpdateStadiumRequest request) {
-        if (request.getName() != null) {
-            this.name = request.getName();
+        try {
+            System.out.println(request);
+            String openTime = Arrays.stream(ReservingTime.values())
+                    .filter(time -> time.getTime().equals(request.getOpenTime()))
+                    .collect(Collectors.toList())
+                    .get(0).toString();
+
+            String closeTime = Arrays.stream(ReservingTime.values())
+                    .filter(time -> time.getTime().equals(request.getCloseTime()))
+                    .collect(Collectors.toList())
+                    .get(0).toString();
+
+            if (request.getName() != null) {
+                this.name = request.getName();
+            }
+
+            if (request.getPhone() != null) {
+                this.phone = request.getPhone();
+            }
+
+            if (request.getLat() != null) {
+                this.lat = request.getLat();
+            }
+
+            if (request.getLnt() != null) {
+                this.lnt = request.getLnt();
+            }
+
+            if (request.getAddress() != null) {
+                this.address = request.getAddress();
+            }
+
+            if (request.getWeekdayPricePerHalfHour() != null) {
+                this.weekdayPricePerHalfHour = request.getWeekdayPricePerHalfHour();
+            }
+
+            if (request.getHolidayPricePerHalfHour() != null) {
+                this.holidayPricePerHalfHour = request.getHolidayPricePerHalfHour();
+            }
+
+            if (request.getOpenTime() != null) {
+                this.openTime = openTime;
+            }
+
+            if (request.getCloseTime() != null) {
+                this.closeTime = closeTime;
+            }
+        } catch (Exception e) {
+            throw new StadiumException(TimeFormatNotAccepted);
         }
 
-        if (request.getPhone() != null) {
-            this.phone = request.getPhone();
-        }
-
-        if (request.getLat() != null) {
-            this.lat = request.getLat();
-        }
-
-        if (request.getLnt() != null) {
-            this.lnt = request.getLnt();
-        }
-
-        if (request.getAddress() != null) {
-            this.address = request.getAddress();
-        }
-
-        if (request.getWeekdayPricePerHalfHour() != null) {
-            this.weekdayPricePerHalfHour = request.getWeekdayPricePerHalfHour();
-        }
-
-        if (request.getHolidayPricePerHalfHour() != null) {
-            this.holidayPricePerHalfHour = request.getHolidayPricePerHalfHour();
-        }
-
-        if (request.getOpenTime() != null) {
-            this.openTime = request.getOpenTime();
-        }
-
-        if (request.getCloseTime() != null) {
-            this.closeTime = request.getCloseTime();
-        }
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -150,7 +150,6 @@ public class Stadium {
 
     public void setAll(StadiumDto.UpdateStadiumRequest request) {
         try {
-            System.out.println(request);
             String openTime = Arrays.stream(ReservingTime.values())
                     .filter(time -> time.getTime().equals(request.getOpenTime()))
                     .collect(Collectors.toList())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumImg.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumImg.java
@@ -1,5 +1,6 @@
 package com.minwonhaeso.esc.stadium.model.entity;
 
+import com.minwonhaeso.esc.stadium.model.dto.StadiumImgDto;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -38,4 +39,17 @@ public class StadiumImg implements Serializable {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public static StadiumImg fromRequest(StadiumImgDto request, Stadium stadium) {
+        return StadiumImg.builder()
+                .stadium(stadium)
+                .imgId(request.getPublicId())
+                .imgUrl(request.getImgUrl())
+                .build();
+    }
+
+    public void setAll(StadiumImgDto request) {
+        this.imgId = request.getPublicId();
+        this.imgUrl = request.getImgUrl();
+    }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
@@ -52,7 +52,7 @@ public class StadiumItem {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public static StadiumItem fromRequest(Stadium stadium, StadiumItemDto.CreateItemRequest request) {
+    public static StadiumItem fromRequest(StadiumItemDto.CreateItemRequest request, Stadium stadium) {
         return StadiumItem.builder()
                 .name(request.getName())
                 .stadium(stadium)
@@ -61,5 +61,12 @@ public class StadiumItem {
                 .price(request.getPrice())
                 .status(AVAILABLE)
                 .build();
+    }
+
+    public void setAll(StadiumItemDto.CreateItemRequest request) {
+        this.name = request.getName();
+        this.imgId = request.getPublicId();
+        this.imgUrl = request.getImgUrl();
+        this.price = request.getPrice();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumItem.java
@@ -63,7 +63,18 @@ public class StadiumItem {
                 .build();
     }
 
-    public void setAll(StadiumItemDto.CreateItemRequest request) {
+    public static StadiumItem fromRequest(StadiumItemDto.UpdateItemRequest request, Stadium stadium) {
+        return StadiumItem.builder()
+                .name(request.getName())
+                .stadium(stadium)
+                .imgId(request.getPublicId())
+                .imgUrl(request.getImgUrl())
+                .price(request.getPrice())
+                .status(AVAILABLE)
+                .build();
+    }
+
+    public void setAll(StadiumItemDto.UpdateItemRequest request) {
         this.name = request.getName();
         this.imgId = request.getPublicId();
         this.imgUrl = request.getImgUrl();

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
@@ -36,15 +36,4 @@ public class StadiumTag {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
-
-    public static StadiumTag fromRequest(StadiumTagDto request, Stadium stadium) {
-        return StadiumTag.builder()
-                .stadium(stadium)
-                .name(request.getTagName())
-                .build();
-    }
-
-    public void setAll(StadiumTagDto request) {
-        this.name = request.getTagName();
-    }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumTag.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.stadium.model.entity;
 
 
+import com.minwonhaeso.esc.stadium.model.dto.StadiumTagDto;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -35,4 +36,15 @@ public class StadiumTag {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public static StadiumTag fromRequest(StadiumTagDto request, Stadium stadium) {
+        return StadiumTag.builder()
+                .stadium(stadium)
+                .name(request.getTagName())
+                .build();
+    }
+
+    public void setAll(StadiumTagDto request) {
+        this.name = request.getTagName();
+    }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/type/ReservingTime.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/type/ReservingTime.java
@@ -3,6 +3,9 @@ package com.minwonhaeso.esc.stadium.model.type;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 @Getter
 @AllArgsConstructor
 public enum ReservingTime {
@@ -57,4 +60,10 @@ public enum ReservingTime {
     RT49("24:00");
 
     private final String time;
+    public static String findTime(String findTime) {
+        return Arrays.stream(ReservingTime.values())
+                .filter(reservingTime -> reservingTime.getTime().equals(findTime))
+                .collect(Collectors.toList())
+                .get(0).toString();
+    }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.stadium.service;
 import com.minwonhaeso.esc.error.exception.StadiumException;
 import com.minwonhaeso.esc.error.type.StadiumErrorCode;
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumLikeRequestDto;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import com.minwonhaeso.esc.stadium.repository.StadiumLikeRepository;
@@ -10,8 +11,6 @@ import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -20,30 +19,21 @@ public class StadiumLikeService {
     private final StadiumLikeRepository stadiumLikeRepository;
     private final StadiumRepository stadiumRepository;
 
-    public Map<String, String> likes(Long stadiumId, String likeDislike, Member member) {
+    public StadiumLikeRequestDto likes(Long stadiumId, Member member) {
         Stadium stadium = stadiumRepository.findById(stadiumId)
                 .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
         Optional<StadiumLike> optionalLike = stadiumLikeRepository.findByMemberAndStadium(member, stadium);
-        likeCD(likeDislike, member, stadium, optionalLike);
-        Map<String,String> map = new HashMap<>();
-        map.put("successMessage","찜하기 반영 성공");
-        return map;
-    }
-
-    private void likeCD(String likeDislike, Member member, Stadium stadium, Optional<StadiumLike> optionalLike) {
-        if (likeDislike.equals("ON")) {
-            if (optionalLike.isEmpty()) {
-                stadiumLikeRepository.save(new StadiumLike(member, stadium));
-            } else {
-                throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
-            }
+        StadiumLikeRequestDto dto = new StadiumLikeRequestDto();
+        if (optionalLike.isEmpty()){
+            stadiumLikeRepository.save(StadiumLike.builder()
+                    .stadium(stadium)
+                    .member(member)
+                    .build());
+            dto.setResult(true);
+            return dto;
         }
-        if (likeDislike.equals("OFF")) {
-            if (optionalLike.isPresent()) {
-                stadiumLikeRepository.delete(optionalLike.get());
-            } else {
-                throw new StadiumException(StadiumErrorCode.LikeRequestAlreadyMatched);
-            }
-        }
+        stadiumLikeRepository.delete(optionalLike.get());
+        dto.setResult(false);
+        return dto;
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumReservationService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumReservationService.java
@@ -208,6 +208,7 @@ public class StadiumReservationService {
         redissonLockReservingTimeFacade.unlock(stadiumId, request.getReservingDate());
 
         return ReservationInfoResponse.builder()
+                .id(reservation.getId())
                 .openTime(stadium.getOpenTime())
                 .closeTime(stadium.getCloseTime())
                 .stadiumId(stadiumId)

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumService.java
@@ -135,63 +135,24 @@ public class StadiumService {
     }
 
     @Transactional
-    public StadiumResponseDto updateStadiumInfo(Member member, Long stadiumId, UpdateStadiumRequest request) {
+    public StadiumInfoResponseDto updateStadiumInfo(Member member, Long stadiumId, UpdateStadiumRequest request) {
         Stadium stadium = stadiumRepository.findById(stadiumId).orElseThrow(
                 () -> new StadiumException(StadiumNotFound));
 
         if (stadium.getMember().getMemberId() != member.getMemberId()) {
             throw new StadiumException(UnAuthorizedAccess);
         }
-
-        // 체육관 기본 정보 수정
+        stadiumTagRepository.deleteAll(stadium.getTags());
+        stadiumImgRepository.deleteAll(stadium.getImgs());
+        stadiumItemRepository.deleteAll(stadium.getRentalStadiumItems());
         stadium.setAll(request);
-
-        // 체육관 이미지 업데이트
-        if (request.getImgs().size() > 0) {
-            request.getImgs().forEach(img -> {
-                if (img.getId() == null) {
-                    stadiumImgRepository.save(StadiumImg.fromRequest(img, stadium));
-                } else {
-                    StadiumImg stadiumImg = stadiumImgRepository.findById(img.getId()).orElseThrow(
-                            () -> new StadiumException(StadiumImgNotFound));
-                    stadiumImg.setAll(img);
-                    stadiumImgRepository.save(stadiumImg);
-                }
-            });
-        }
-
-        // 체육관 종목 업데이트
-        if (request.getTags().size() > 0) {
-            request.getTags().forEach(tag -> {
-                if (tag.getId() == null) {
-                    stadiumTagRepository.save(StadiumTag.fromRequest(tag, stadium));
-                } else {
-                    StadiumTag stadiumTag = stadiumTagRepository.findById(tag.getId()).orElseThrow(
-                            () -> new StadiumException(StadiumTagNotFound));
-                    stadiumTag.setAll(tag);
-                    stadiumTagRepository.save(stadiumTag);
-                }
-            });
-        }
-
-        // 체육관 아이템 업데이트
-        if (request.getItems().size() > 0) {
-            request.getItems().forEach(item -> {
-                if (item.getId() == null) {
-                    stadiumItemRepository.save(StadiumItem.fromRequest(item, stadium));
-                } else {
-                    StadiumItem stadiumItem = stadiumItemRepository.findById(item.getId()).orElseThrow(
-                            () -> new StadiumException(StadiumItemNotFound));
-                    stadiumItem.setAll(item);
-                    stadiumItemRepository.save(stadiumItem);
-                }
-            });
-        }
-
+        stadiumTagRepository.saveAll(stadium.getTags());
+        stadiumImgRepository.saveAll(stadium.getImgs());
+        stadiumItemRepository.saveAll(stadium.getRentalStadiumItems());
         stadiumRepository.save(stadium);
         StadiumDocument stadiumDocument = StadiumDocument.fromEntity(stadium);
         stadiumSearchRepository.save(stadiumDocument);
-        return StadiumResponseDto.fromEntity(stadium);
+        return StadiumInfoResponseDto.fromEntity(stadium);
     }
 
     public StadiumTagDto addStadiumTag(Member member, Long stadiumId, String tagName) {

--- a/src/test/java/com/minwonhaeso/esc/stadium/config/QuerydslTestConfiguration.java
+++ b/src/test/java/com/minwonhaeso/esc/stadium/config/QuerydslTestConfiguration.java
@@ -1,0 +1,19 @@
+package com.minwonhaeso.esc.stadium.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class QuerydslTestConfiguration {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
### Background
---
- 프론트 UI Test 도중 상의해서 수정한 내용들입니다.

### Change
---
- [X] 이메일 키 인증 Request Body 수정
- [X] 비밀번호 변경 키 인증 Request Body 수정
- [X] 리뷰 Response의 createdAt -> String값으로 리턴
- [X] 찜하기 & 취소 관련 로직 변경
- [X] 체육관 상세 정보 Response Body의 변수명 변경 items -> rentalItems
- [X] 찜하기 요청 Request Body 수정
- [X] Stadium에 likes 컬럼(주석) 삭제
- [X] 체육관 생성 & 수정 관련 openTime, closeTime 처리 로직 수정
프론트에서는 String으로 관리 서버에서는 enum으로 관리(Reserving Time)
- 

### Test
---
- UI Test 완료

### Discuss
---
- 이미 해찬님이 변경하셔서 PR에 올라온 부분도 있어서 충돌이 일어날 수도 있을 것 같아요!
- 리뷰 테스트 도중에 변경이 필요한 부분이 있습니다 #57 
