### PR TITLE
Fix : 리뷰 API 수정 및 알림 기능 구현 #57

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/InfoDto.java
@@ -3,7 +3,6 @@ package com.minwonhaeso.esc.member.model.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 public class InfoDto {
 
@@ -11,6 +10,7 @@ public class InfoDto {
     @Getter
     @AllArgsConstructor
     public static class Response{
+        private Long id;
         private String nickname;
         private String name;
         private String email;

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/LoginDto.java
@@ -26,13 +26,14 @@ public class LoginDto {
     public static class Response {
         private String accessToken;
         private String refreshToken;
+        private Long id;
         private String name;
         private String nickname;
         private String imgUrl;
 
-
-        public static Response of(String username, String nickname, String imgUrl, String accessToken, String refreshToken) {
+        public static Response of(Long id, String username, String nickname, String imgUrl, String accessToken, String refreshToken) {
             return Response.builder()
+                    .id(id)
                     .name(username)
                     .nickname(nickname)
                     .imgUrl(imgUrl)

--- a/src/main/java/com/minwonhaeso/esc/member/model/dto/OAuthDto.java
+++ b/src/main/java/com/minwonhaeso/esc/member/model/dto/OAuthDto.java
@@ -22,6 +22,7 @@ public class OAuthDto {
     @NoArgsConstructor
     @ApiModel(value = "소셜 로그인 Response Body")
     public static class Response {
+        private Long id;
         private String nickname;
         private String imgUrl;
         private String refreshToken;

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
         String email = member.getEmail();
         String accessToken = jwtTokenUtil.generateAccessToken(email);
         RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(email);
-        return LoginDto.Response.of(email,member.getNickname(), member.getImgUrl(), accessToken, refreshToken.getRefreshToken());
+        return LoginDto.Response.of(member.getMemberId(), email, member.getNickname(), member.getImgUrl(), accessToken, refreshToken.getRefreshToken());
     }
 
     private void checkPassword(String rawPassword, String findMemberPassword) {
@@ -140,6 +140,7 @@ public class MemberService {
         Member member = memberRepository.findByEmail(user.getUsername())
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MemberNotLogIn));
         return InfoDto.Response.builder()
+                .id(member.getMemberId())
                 .nickname(member.getNickname())
                 .email(member.getEmail())
                 .imgUrl(member.getImgUrl())
@@ -247,6 +248,7 @@ public class MemberService {
         RefreshToken refreshToken = jwtTokenUtil.saveRefreshToken(email);
 
         return OAuthDto.Response.builder()
+                .id(member.getMemberId())
                 .nickname(member.getNickname())
                 .imgUrl(member.getImgUrl())
                 .refreshToken(refreshToken.getRefreshToken())

--- a/src/main/java/com/minwonhaeso/esc/notification/model/type/NotificationType.java
+++ b/src/main/java/com/minwonhaeso/esc/notification/model/type/NotificationType.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum NotificationType {
-    REVIEW("/stadiums/{}/info"),
-    RESERVATION("/stadiums/{}/reservations/{}");
+    REVIEW("/stadiums/%d/info"),
+    RESERVATION("/stadiums/%d/reservations/%d");
 
     private final String url;
 }

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class ReviewDto {
     @Getter
@@ -27,18 +29,23 @@ public class ReviewDto {
     @ApiModel(value = "리뷰 Response Body")
     public static class Response {
         private Long id;
+        private Long memberId;
         private Double star;
         private String comment;
         private String nickname;
-        private LocalDate createdAt;
+        private String imgUrl;
+        private String createdAt;
 
         public static ReviewDto.Response fromEntity(Review review) {
             return Response.builder()
                     .id(review.getId())
+                    .memberId(review.getMember().getMemberId())
                     .star(review.getStar())
                     .comment(review.getComment())
                     .nickname(review.getMember().getNickname())
-                    .createdAt(review.getCreatedAt())
+                    .imgUrl(review.getMember().getImgUrl())
+                    .createdAt(review.getCreatedAt().format(DateTimeFormatter
+                            .ofPattern("yyyy-MM-dd a HH:mm").withLocale(Locale.forLanguageTag("ko"))))
                     .build();
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/dto/ReviewDto.java
@@ -1,5 +1,6 @@
 package com.minwonhaeso.esc.review.model.dto;
 
+import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.entity.Review;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
@@ -7,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
@@ -29,23 +29,41 @@ public class ReviewDto {
     @ApiModel(value = "리뷰 Response Body")
     public static class Response {
         private Long id;
-        private Long memberId;
+        private MemberResponse member;
         private Double star;
         private String comment;
-        private String nickname;
-        private String imgUrl;
         private String createdAt;
 
         public static ReviewDto.Response fromEntity(Review review) {
             return Response.builder()
                     .id(review.getId())
-                    .memberId(review.getMember().getMemberId())
+                    .member(MemberResponse.fromEntity(review.getMember()))
                     .star(review.getStar())
                     .comment(review.getComment())
-                    .nickname(review.getMember().getNickname())
-                    .imgUrl(review.getMember().getImgUrl())
                     .createdAt(review.getCreatedAt().format(DateTimeFormatter
                             .ofPattern("yyyy-MM-dd a HH:mm").withLocale(Locale.forLanguageTag("ko"))))
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    private static class MemberResponse {
+        private Long id;
+        private String email;
+        private String nickname;
+        private String name;
+        private String imgUrl;
+
+        public static ReviewDto.MemberResponse fromEntity(Member member) {
+            return MemberResponse.builder()
+                    .id(member.getMemberId())
+                    .email(member.getEmail())
+                    .nickname(member.getNickname())
+                    .name(member.getName())
+                    .imgUrl(member.getImgUrl())
                     .build();
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
+++ b/src/main/java/com/minwonhaeso/esc/review/model/entity/Review.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -36,7 +37,7 @@ public class Review {
     private String comment;
 
     @CreatedDate
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
 
     public void update(Double star, String comment) {
         this.star = star;

--- a/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
+++ b/src/main/java/com/minwonhaeso/esc/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.review.service;
 import com.minwonhaeso.esc.error.exception.ReviewException;
 import com.minwonhaeso.esc.error.exception.StadiumException;
 import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.notification.service.NotificationService;
 import com.minwonhaeso.esc.review.model.dto.ReviewDto;
 import com.minwonhaeso.esc.review.model.entity.Review;
 import com.minwonhaeso.esc.review.repository.ReviewRepository;
@@ -17,10 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 import static com.minwonhaeso.esc.error.type.ReviewErrorCode.*;
 import static com.minwonhaeso.esc.error.type.StadiumErrorCode.StadiumNotFound;
+import static com.minwonhaeso.esc.notification.model.type.NotificationType.REVIEW;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -30,6 +30,7 @@ public class ReviewService {
 
     private final StadiumRepository stadiumRepository;
     private final StadiumReservationRepository stadiumReservationRepository;
+    private final NotificationService notificationService;
 
     @Transactional(readOnly = true)
     public Page<ReviewDto.Response> getAllReviewsByStadium(Long stadiumId, Pageable pageable) {
@@ -63,6 +64,10 @@ public class ReviewService {
 
         reviewRepository.save(review);
         log.info("회원 번호 [ " + member.getMemberId() + " ] -  리뷰를 작성하였습니다.");
+
+        notificationService.createNotification(REVIEW, stadiumId, 0L,
+                "체육관 [ " + stadium.getName() + " ]에 새로운 리뷰가 등록되었습니다.", stadium.getMember());
+        log.info("회원 번호 [ " + stadium.getMember().getMemberId() + " ] 로 알람이 발송되었습니다.");
 
         return ReviewDto.Response.fromEntity(review);
     }


### PR DESCRIPTION
### Background
---
- 리뷰를 시간 순서대로 정렬 하기 위해 시간 정보가 필요
- 리뷰 리스트 전송 시, 리뷰 작성한 회원 정보 필요
- 리뷰 작성 시, 알림 기능 구현
- #57 

### Change
---
- createdAt : LocalDate -> LocalDateTime
- 생성정보를 response에서 오전/오후 및 간결하게 표현할 수 있도록 하였음
- 추가로 memberId와 imgUrl 함께 전송
- 리뷰 생성 시, 체육관 관리자에게 알람 정보 저장
- NotificationType의 Url 표현 수정

### Test
---
- Postman을 통해 테스트를 진행하였습니다.

### Discuss
---
- 댓글에서 수정삭제버튼을 보일지 말지 결정하기 위해 리뷰 넘겨주는 response에 현재 접속한 멤버의 id값을 넘겨주는 부분에 대해 고민 중인데, 우선 리뷰 리스트를 받아올 때 각 리뷰를 작성한 memberId를 보내도록 하였습니다.
- 현재 접속한 멤버의 정보(email, nickname)는 상태유지로 프론트에서 저장중인 걸로 알고 있는데, 
  해당 부분에 대해서는 재원님과 다시 얘기해보겠습니다!
  - 가지고 있는 정보가 email, nickname이기 때문에 현재 접속중인 memberId가 아닌 리스트 내 리뷰 작성자에 해당하는 email을 넘겨주어도 확인이 가능하지 않을까 생각합니다. 
