### PR TITLE
Fix : 체육관 예약 관련 API 수정 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,23 +36,24 @@ dependencies{
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.redisson:redisson-spring-boot-starter:3.17.4'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.ibm.icu:icu4j:51.1'
     implementation "com.querydsl:querydsl-core" // querydsl
     implementation "com.querydsl:querydsl-jpa" // querydsl
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
-    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
-    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
-    testCompileOnly 'com.h2database:h2'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.0.8'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '3.0.0'
     implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.0.8'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    testCompileOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ dependencies{
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    compileOnly "com.querydsl:querydsl-core" // querydsl
-    compileOnly "com.querydsl:querydsl-jpa" // querydsl
+    implementation "com.querydsl:querydsl-core" // querydsl
+    implementation "com.querydsl:querydsl-jpa" // querydsl
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
@@ -13,6 +13,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,7 +46,8 @@ public class StadiumReservationController {
     @GetMapping("/{stadiumId}/reservation")
     public ResponseEntity<?> getStadiumReservationInfo(
             @PathVariable Long stadiumId,
-            @RequestParam(value = "date", required = false) LocalDate date
+            @RequestParam(value = "date", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
             ) {
 
         if (date == null) {

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
@@ -98,6 +98,17 @@ public class StadiumReservationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(reservationInfo);
     }
 
+    @PatchMapping("/{stadiumId}/reservations/{reservationId}")
+    public ResponseEntity<?> executeReservation(
+            @AuthenticationPrincipal PrincipalDetail principalDetail,
+            @PathVariable Long stadiumId,
+            @PathVariable Long reservationId
+    ) {
+        Member member = principalDetail.getMember();
+        stadiumReservationService.executeReservation(member, stadiumId, reservationId);
+        return ResponseEntity.ok().build();
+    }
+
     @DeleteMapping("/{stadiumId}/reservations/{reservationId}")
     public ResponseEntity<?> deleteReservation(
             @AuthenticationPrincipal PrincipalDetail principalDetail,

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumReservationController.java
@@ -5,9 +5,7 @@ import com.minwonhaeso.esc.notification.model.type.NotificationType;
 import com.minwonhaeso.esc.notification.service.NotificationService;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto;
-import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto.CreateReservationRequest;
-import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto.PriceResponse;
-import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto.ReservationInfoResponse;
+import com.minwonhaeso.esc.stadium.model.dto.StadiumReservationDto.*;
 import com.minwonhaeso.esc.stadium.service.StadiumReservationService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +35,7 @@ public class StadiumReservationController {
             Pageable pageable
     ) {
         Member member = principalDetail.getMember();
-        Page<StadiumReservationDto.Response> reservations =
+        Page<ReservationResponse> reservations =
                 stadiumReservationService.getAllReservationsByMember(member, pageable);
         return ResponseEntity.ok().body(reservations);
     }
@@ -54,7 +52,7 @@ public class StadiumReservationController {
             date = LocalDate.now();
         }
 
-        ReservationInfoResponse reservationInfo =
+        ReservationStadiumInfoResponse reservationInfo =
                 stadiumReservationService.getStadiumReservationInfo(stadiumId, date);
         return ResponseEntity.ok().body(reservationInfo);
     }
@@ -90,10 +88,10 @@ public class StadiumReservationController {
 
     ) {
         Member member = principalDetail.getMember();
-        ReservationInfoResponse reservationInfo =
+        StadiumReservationDto.CreateReservationResponse reservationInfo =
                 stadiumReservationService.createReservation(member, stadiumId, request);
         notificationService.createNotification(
-                NotificationType.RESERVATION, stadiumId, reservationInfo.getId(),
+                NotificationType.RESERVATION, stadiumId, reservationInfo.getReservationId(),
                 "새로운 예약이 있습니다.", member);
         return ResponseEntity.status(HttpStatus.CREATED).body(reservationInfo);
     }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -2,10 +2,12 @@ package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumTag;
-import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -74,8 +76,8 @@ public class StadiumInfoResponseDto {
                 .starAvg(stadium.getStarAvg())
                 .weekdayPricePerHalfHour(stadium.getWeekdayPricePerHalfHour())
                 .holidayPricePerHalfHour(stadium.getHolidayPricePerHalfHour())
-                .openTime(ReservingTime.valueOf(stadium.getOpenTime()).getTime())
-                .closeTime(ReservingTime.valueOf(stadium.getCloseTime()).getTime())
+                .openTime(stadium.getOpenTime().getTime())
+                .closeTime(stadium.getCloseTime().getTime())
                 .rentalItems(stadium.getRentalStadiumItems().stream()
                         .map(StadiumItemDto.Response::fromEntity)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumInfoResponseDto.java
@@ -19,6 +19,9 @@ public class StadiumInfoResponseDto {
     @ApiModelProperty(value = "체육관 ID", example = "1")
     private Long id;
 
+    @ApiModelProperty(value = "현재 접속한 사용자 아이디")
+    private Long memberId;
+
     @ApiModelProperty(value = "체육관 이름", example = "수원 국립 체육관")
     private String name;
 
@@ -61,6 +64,7 @@ public class StadiumInfoResponseDto {
     public static StadiumInfoResponseDto fromEntity(Stadium stadium) {
         return StadiumInfoResponseDto.builder()
                 .id(stadium.getId())
+                .memberId(stadium.getMember().getMemberId())
                 .name(stadium.getName())
                 .lat(stadium.getLat())
                 .lnt(stadium.getLnt())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
@@ -47,19 +47,20 @@ public class StadiumReservationDto {
         private Long id;
         private StadiumResponseDto stadium;
         private MemberResponse member;
-        private LocalDate reservingDate;
+        private String reservingDate;
         private List<String> reservingTimes;
         private int headCount;
         private int price;
         private String paymentType;
         private List<ItemResponse> items;
+        private String status;
 
         public static Response fromEntity(StadiumReservation reservation) {
             return Response.builder()
                     .id(reservation.getId())
                     .stadium(StadiumResponseDto.fromEntity(reservation.getStadium()))
                     .member(MemberResponse.fromEntity(reservation.getMember()))
-                    .reservingDate(reservation.getReservingDate())
+                    .reservingDate(reservation.getReservingDate().toString())
                     .reservingTimes(reservation.getReservingTimes().stream()
                             .map(ReservingTime::getTime)
                             .collect(Collectors.toList()))
@@ -67,6 +68,7 @@ public class StadiumReservationDto {
                     .price(reservation.getPrice())
                     .paymentType(reservation.getPaymentType().toString())
                     .items(ItemResponse.fromReservation(reservation))
+                    .status(reservation.getStatus().toString())
                     .build();
         }
     }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
@@ -33,11 +33,11 @@ public class StadiumReservationDto {
         private Long id;
         private Long stadiumId;
         private String stadiumName;
-        private LocalDate date;
+        private String date;
         private String openTime;
         private String closeTime;
         private int pricePerHalfHour;
-        private List<ItemResponse> items;
+        private List<ItemResponse> rentalItems;
         private List<String> reservedTimes;
     }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumReservationDto.java
@@ -1,14 +1,11 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.minwonhaeso.esc.member.model.entity.Member;
-import com.minwonhaeso.esc.stadium.model.entity.StadiumItem;
-import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
-import com.minwonhaeso.esc.stadium.model.entity.StadiumReservationItem;
+import com.minwonhaeso.esc.stadium.model.entity.*;
 import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,8 +26,22 @@ public class StadiumReservationDto {
 
     @Data
     @Builder
-    public static class ReservationInfoResponse {
-        private Long id;
+    @ApiModel(value = "예약 내역 체육관 정보 Response")
+    public static class ReservationStadiumInfoResponse {
+        private Stadium stadium;
+        private String date;
+        private String openTime;
+        private String closeTime;
+        private int pricePerHalfHour;
+        private List<ItemResponse> rentalItems;
+        private List<String> reservedTimes;
+    }
+
+    @Data
+    @Builder
+    @ApiModel(value = "예약 생성 정보 Response")
+    public static class CreateReservationResponse {
+        private Long reservationId;
         private Long stadiumId;
         private String stadiumName;
         private String date;
@@ -43,31 +54,62 @@ public class StadiumReservationDto {
 
     @Data
     @Builder
-    public static class Response {
-        private Long id;
-        private StadiumResponseDto stadium;
+    @ApiModel(value = "예약 상세 내역 정보 Response")
+    public static class ReservationInfoResponse {
+        private Long reservationId;
+        private Long stadiumId;
+        private String name;
+        private String status;
         private MemberResponse member;
         private String reservingDate;
-        private List<String> reservingTimes;
+        private List<String> reservingTime;
         private int headCount;
         private int price;
         private String paymentType;
         private List<ItemResponse> items;
-        private String status;
 
-        public static Response fromEntity(StadiumReservation reservation) {
-            return Response.builder()
-                    .id(reservation.getId())
-                    .stadium(StadiumResponseDto.fromEntity(reservation.getStadium()))
+        public static ReservationInfoResponse fromEntity(StadiumReservation reservation) {
+            return ReservationInfoResponse.builder()
+                    .reservationId(reservation.getId())
+                    .stadiumId(reservation.getStadium().getId())
+                    .name(reservation.getStadium().getName())
                     .member(MemberResponse.fromEntity(reservation.getMember()))
                     .reservingDate(reservation.getReservingDate().toString())
-                    .reservingTimes(reservation.getReservingTimes().stream()
+                    .reservingTime(reservation.getReservingTimes().stream()
                             .map(ReservingTime::getTime)
                             .collect(Collectors.toList()))
                     .headCount(reservation.getHeadCount())
                     .price(reservation.getPrice())
                     .paymentType(reservation.getPaymentType().toString())
                     .items(ItemResponse.fromReservation(reservation))
+                    .status(reservation.getStatus().toString())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ApiModel(value = "예약 내역 리스트 정보 Response")
+    public static class ReservationResponse {
+        private Long reservationId;
+        private Long stadiumId;
+        private String name;
+        private String address;
+        private String imgUrl;
+        private Double starAvg;
+        private String status;
+
+        public static ReservationResponse fromEntity(StadiumReservation reservation) {
+            Stadium stadium = reservation.getStadium();
+            return ReservationResponse.builder()
+                    .reservationId(reservation.getId())
+                    .stadiumId(stadium.getId())
+                    .name(stadium.getName())
+                    .address(stadium.getAddress() + " " + stadium.getDetailAddress())
+                    .imgUrl(stadium.getImgs().get(0).getImgUrl())
+                    .starAvg(stadium.getStarAvg())
                     .status(reservation.getStatus().toString())
                     .build();
         }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -84,17 +84,30 @@ public class Stadium {
     private Member member;
 
     @Builder.Default
-    @OneToMany(mappedBy = "stadium")
+    @OneToMany(
+            mappedBy = "stadium",
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            orphanRemoval = true)
     private List<StadiumItem> rentalStadiumItems = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "stadium")
+    @OneToMany(
+            mappedBy = "stadium",
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            orphanRemoval = true)
     private List<StadiumImg> imgs = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "stadium")
+    @OneToMany(
+            mappedBy = "stadium",
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            orphanRemoval = true)
     private List<StadiumTag> tags = new ArrayList<>();
-    @OneToMany(mappedBy = "stadium")
+
+    @OneToMany(
+            mappedBy = "stadium",
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            orphanRemoval = true)
     @Column(name = "reviews")
     private List<Review> reviews;
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/Stadium.java
@@ -5,7 +5,6 @@ import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.review.model.entity.Review;
 import com.minwonhaeso.esc.stadium.model.dto.StadiumDto;
 import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
-import com.minwonhaeso.esc.stadium.model.type.StadiumItemStatus;
 import com.sun.istack.NotNull;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -70,11 +68,13 @@ public class Stadium {
 
     @NotNull
     @Column(name = "open_time", nullable = false)
-    private String openTime;
+    @Enumerated(EnumType.STRING)
+    private ReservingTime openTime;
 
     @NotNull
     @Column(name = "close_time", nullable = false)
-    private String closeTime;
+    @Enumerated(EnumType.STRING)
+    private ReservingTime closeTime;
 
     @Column(name = "star_avg")
     private Double starAvg;
@@ -130,8 +130,8 @@ public class Stadium {
 
     public static Stadium fromRequest(StadiumDto.CreateStadiumRequest request, Member member) {
         try {
-            String openTime = ReservingTime.findTime(request.getOpenTime());
-            String closeTime = ReservingTime.findTime(request.getCloseTime());
+            ReservingTime openTime = ReservingTime.findTime(request.getOpenTime());
+            ReservingTime closeTime = ReservingTime.findTime(request.getCloseTime());
 
             return Stadium.builder()
                     .member(member)
@@ -154,8 +154,8 @@ public class Stadium {
 
     public void setAll(StadiumDto.UpdateStadiumRequest request) {
         try {
-            String openTime = ReservingTime.findTime(request.getOpenTime());
-            String closeTime = ReservingTime.findTime(request.getCloseTime());
+            ReservingTime openTime = ReservingTime.findTime(request.getOpenTime());
+            ReservingTime closeTime = ReservingTime.findTime(request.getCloseTime());
 
             if (request.getName() != null) {
                 this.name = request.getName();

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
@@ -63,6 +63,10 @@ public class StadiumReservation {
     @ApiModelProperty(name = "결제 타입")
     private PaymentType paymentType;
 
+    public void executeReservation() {
+        this.status = StadiumReservationStatus.EXECUTED;
+    }
+
     public void cancelReservation() {
         this.status = StadiumReservationStatus.CANCELED;
     }
@@ -86,6 +90,4 @@ public class StadiumReservation {
                 .paymentType(PaymentType.valueOf(request.getPaymentType()))
                 .build();
     }
-
-
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/entity/StadiumReservation.java
@@ -82,7 +82,7 @@ public class StadiumReservation {
                 .member(member)
                 .reservingDate(request.getReservingDate())
                 .reservingTimes(request.getReservingTimes().stream()
-                        .map(ReservingTime::valueOf)
+                        .map(time -> ReservingTime.findTime(time))
                         .collect(Collectors.toList()))
                 .price(price)
                 .headCount(request.getHeadCount())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/type/ReservingTime.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/type/ReservingTime.java
@@ -60,10 +60,10 @@ public enum ReservingTime {
     RT49("24:00");
 
     private final String time;
-    public static String findTime(String findTime) {
+    public static ReservingTime findTime(String findTime) {
         return Arrays.stream(ReservingTime.values())
                 .filter(reservingTime -> reservingTime.getTime().equals(findTime))
                 .collect(Collectors.toList())
-                .get(0).toString();
+                .get(0);
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @Repository
 public interface StadiumReservationRepository extends JpaRepository<StadiumReservation, Long> {
-    Page<StadiumReservation> findAllByMemberAndStatusAndReservingDateAfter(
+    Page<StadiumReservation> findAllByMemberAndStatusAndReservingDateAfterOrderByReservingDateDesc(
             Member member, StadiumReservationStatus status, LocalDate reservingDate, Pageable pageable);
     List<StadiumReservation> findAllByStadiumAndReservingDate(Stadium stadium, LocalDate reservingDate);
     Long countAllByMemberAndStadiumAndStatusIs(Member member, Stadium stadium, StadiumReservationStatus status);

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumService.java
@@ -94,12 +94,6 @@ public class StadiumService {
             throw new StadiumException(UnAuthorizedAccess);
         }
 
-        List<StadiumItem> items = stadiumItemRepository.findAllByStadium(stadium);
-        List<StadiumImg> imgs = stadiumImgRepository.findAllByStadium(stadium);
-        List<StadiumTag> tags = stadiumTagRepository.findAllByStadium(stadium);
-        stadiumItemRepository.deleteAll(items);
-        stadiumImgRepository.deleteAll(imgs);
-        stadiumTagRepository.deleteAll(tags);
         stadiumSearchRepository.deleteById(stadiumId);
         stadiumRepository.delete(stadium);
     }

--- a/src/main/java/com/minwonhaeso/esc/util/HolidayUtil.java
+++ b/src/main/java/com/minwonhaeso/esc/util/HolidayUtil.java
@@ -1,16 +1,208 @@
 package com.minwonhaeso.esc.util;
 
+import com.ibm.icu.util.ChineseCalendar;
+
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Calendar;
 
 public class HolidayUtil {
+    private static String[] solarArr = new String[]{"0101", "0301", "0505", "0606", "0815", "1003", "1009", "1225"};
+    private static String[] lunarArr = new String[]{"0101", "0102", "0408", "0814", "0815", "0816"};
+
+    /**
+     * 해당일자가 법정공휴일, 대체공휴일, 토요일, 일요일인지 확인
+     * @param date 양력날짜 (yyyyMMdd)
+     * @return 법정공휴일, 대체공휴일, 일요일이면 true, 오류시 false
+     */
+    public static boolean isHoliday(LocalDate date) {
+        String dateString = String.join("", date.toString().split("-"));
+        return isHolidaySolar(dateString) || isHolidayLunar(dateString) || isHolidayAlternate(dateString) || isWeekend(date);
+    }
+
+    private static boolean isHolidayAlternate(String date) {
+
+        String[] altHoliday = new String[] {
+                "20150929", "20160210", "20170130", "20180926",
+                "20180507", "20190506", "20200127", "20220912",
+                "20230124", "20240212", "20240506", "20251008",
+                "20270209", "20290924", "20290507"};
+
+        return Arrays.asList(altHoliday).contains(date);
+
+        /*
+        int year = Integer.parseInt(date.substring(0, 4));
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+
+        // 설날
+        String dayFirst2 = convertLunarToSolar(year + "0101");
+        String dayFirst3 = convertLunarToSolar(year + "0102");
+        String dayFirst1 = String.valueOf(Integer.parseInt(dayFirst2) - 1);
+
+        // 추석
+        String dayThanks1 = convertLunarToSolar(year + "0814");
+        String dayThanks2 = convertLunarToSolar(year + "0815");
+        String dayThanks3 = convertLunarToSolar(year + "0816");
+
+        // 어린이날
+        String dayChild = year + "0505";
+
+        // 해당 년도의 대체휴일 목록
+        List<String> altHoliday = new ArrayList<String>();
+
+        if(getDayOfWeek(dayFirst1) == Calendar.SUNDAY || getDayOfWeek(dayFirst2) == Calendar.SUNDAY || getDayOfWeek(dayFirst3) == Calendar.SUNDAY || isHolidaySolar(dayFirst1) || isHolidaySolar(dayFirst2) || isHolidaySolar(dayFirst3)) {
+            int y = Integer.parseInt(dayFirst3.substring(0, 4));
+            int m = Integer.parseInt(dayFirst3.substring(4, 6)) - 1;
+            int d = Integer.parseInt(dayFirst3.substring(6)) + 1;
+            Calendar c = Calendar.getInstance();
+            c.set(y, m, d);
+            altHoliday.add(sdf.format(c.getTime()));
+        }
+
+        if(getDayOfWeek(dayThanks1) == Calendar.SUNDAY || getDayOfWeek(dayThanks2) == Calendar.SUNDAY || getDayOfWeek(dayThanks3) == Calendar.SUNDAY || isHolidaySolar(dayThanks1) || isHolidaySolar(dayThanks2) || isHolidaySolar(dayThanks3)) {
+            int y = Integer.parseInt(dayThanks3.substring(0, 4));
+            int m = Integer.parseInt(dayThanks3.substring(4, 6)) - 1;
+            int d = Integer.parseInt(dayThanks3.substring(6)) + 1;
+            Calendar c = Calendar.getInstance();
+            c.set(y, m, d);
+            altHoliday.add(sdf.format(c.getTime()));
+        }
+
+        int childWeek = getDayOfWeek(dayChild);
+
+        if(childWeek == Calendar.SATURDAY) {
+            int y = Integer.parseInt(dayChild.substring(0, 4));
+            int m = Integer.parseInt(dayChild.substring(4, 6)) - 1;
+            int d = Integer.parseInt(dayChild.substring(6)) + 2;
+            Calendar c = Calendar.getInstance();
+            c.set(y, m, d);
+            altHoliday.add(sdf.format(c.getTime()));
+        }
+
+        if(childWeek == Calendar.SUNDAY) {
+            int y = Integer.parseInt(dayChild.substring(0, 4));
+            int m = Integer.parseInt(dayChild.substring(4, 6)) - 1;
+            int d = Integer.parseInt(dayChild.substring(6)) + 1;
+            Calendar c = Calendar.getInstance();
+            c.set(y, m, d);
+            altHoliday.add(sdf.format(c.getTime()));
+        }
+
+        return altHoliday.contains(date);
+        */
+    }
+
+
+    /**
+     * 해당일자가 음력 법정공휴일에 해당하는 지 확인
+     */
+    private static boolean isHolidayLunar(String date) {
+        try {
+            Calendar cal = Calendar.getInstance();
+            ChineseCalendar chinaCal = new ChineseCalendar();
+
+            cal.set(Calendar.YEAR, Integer.parseInt(date.substring(0, 4)));
+            cal.set(Calendar.MONTH, Integer.parseInt(date.substring(4, 6)) - 1);
+            cal.set(Calendar.DAY_OF_MONTH, Integer.parseInt(date.substring(6)));
+
+            chinaCal.setTimeInMillis(cal.getTimeInMillis());
+
+            // 음력으로 변환된 월과 일자
+            int mm = chinaCal.get(ChineseCalendar.MONTH) + 1;
+            int dd = chinaCal.get(ChineseCalendar.DAY_OF_MONTH);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("%02d", mm));
+            sb.append(String.format("%02d", dd));
+
+            // 음력 12월의 마지막날 (설날 첫번째 휴일)인지 확인
+            if (mm == 12) {
+                int lastDate = chinaCal.getActualMaximum(ChineseCalendar.DAY_OF_MONTH);
+                if (dd == lastDate) {
+                    return true;
+                }
+            }
+
+            // 음력 휴일에 포함되는지 여부 리턴
+            return Arrays.asList(lunarArr).contains(sb.toString());
+        } catch(Exception ex) {
+            System.out.println(ex.getStackTrace());
+            return false;
+        }
+    }
+
+
+    /**
+     * 해당일자가 양력 법정공휴일에 해당하는 지 확인
+     * @param date 양력날짜 (yyyyMMdd)
+     * @return 양력 공휴일이면 true
+     */
+    private static boolean isHolidaySolar(String date) {
+        try {
+            // 공휴일에 포함 여부 리턴
+            return Arrays.asList(solarArr).contains(date.substring(4));
+        } catch(Exception ex) {
+            System.out.println(ex.getStackTrace());
+            return false;
+        }
+    }
+
+
+    /**
+     * 음력날짜를 양력날짜로 변환
+     */
+    private static String convertLunarToSolar(String yyyymmdd) {
+        ChineseCalendar cc = new ChineseCalendar();
+        Calendar cal = Calendar.getInstance();
+
+        if (yyyymmdd == null)
+            return "";
+
+        String date = yyyymmdd.trim();
+        if (date.length() != 8) {
+            if (date.length() == 4)
+                date = date + "0101";
+            else if (date.length() == 6)
+                date = date + "01";
+            else if (date.length() > 8)
+                date = date.substring(0, 8);
+            else
+                return "";
+        }
+
+        cc.set(ChineseCalendar.EXTENDED_YEAR, Integer.parseInt(date.substring(0, 4)) + 2637);
+        cc.set(ChineseCalendar.MONTH, Integer.parseInt(date.substring(4, 6)) - 1);
+        cc.set(ChineseCalendar.DAY_OF_MONTH, Integer.parseInt(date.substring(6)));
+
+        cal.setTimeInMillis(cc.getTimeInMillis());
+
+        int y = cal.get(Calendar.YEAR);
+        int m = cal.get(Calendar.MONTH) + 1;
+        int d = cal.get(Calendar.DAY_OF_MONTH);
+
+        StringBuffer ret = new StringBuffer();
+        ret.append(String.format("%04d", y));
+        ret.append(String.format("%02d", m));
+        ret.append(String.format("%02d", d));
+
+        return ret.toString();
+    }
+
     public static boolean isWeekend(LocalDate date) {
         return date.getDayOfWeek() == DayOfWeek.SATURDAY ||
                 date.getDayOfWeek() == DayOfWeek.SUNDAY;
     }
 
-    public static boolean isHoliday(LocalDate date) {
-        // TODO: 법정 공휴일 추가 예정
-        return false;
+    /**
+     * 양력날짜의 요일을 리턴
+     */
+    private static int getDayOfWeek(String day) {
+        int y = Integer.parseInt(day.substring(0, 4));
+        int m = Integer.parseInt(day.substring(4, 6)) - 1;
+        int d = Integer.parseInt(day.substring(6));
+        Calendar c = Calendar.getInstance();
+        c.set(y, m, d);
+        return c.get(Calendar.DAY_OF_WEEK);
     }
 }


### PR DESCRIPTION
### Background
---
- build.gradle 정리 및 test를 위해 몇가지 수정이 필요했음.
- 체육관 예약 관련 사용 완료 API 추가가 필요했음.
- 체육관 예약시 가격 체크하는 부분을 위해서 휴일 라이브러리 보완이 필요했음.(HolidayUtil 파일)
- 그외 프론트로 보내는 데이터에 대한 DTO 수정이 필요했음.

### Change
---
- [X] build.gradle에 querydls 라이브러리를 테스트 코드에도 사용할 수 있게 수정 및 정리
- [X] 양력 날짜를 음력 날짜로 바꾸는 라이브러리 추가(휴일 확인을 위해)
- [X] 예약 API 수정(쿼리 파라미터로 들어오는 날짜형식 데이터의 파싱 관련 DateTimeFormat 추가 설정
- [X] 예약 API 추가(사용 완료 API 추가)
- [X] 체육관 상세 정보에 등록한 매니저 아이디 추가
- [X] 오픈시간, 마감시간 관련 DTO 수정
- [X] 체육관 엔티티에 cascade와 orphanrRemoval 옵션 추가
- [X] 예약 내역 조회시 시간순 내림차순으로 조회하도록 변경
- [X] 공휴일 관련해서 Util 클래스에 공휴일인지 체크하는 로직을 추가

### Test
---
- 오늘 UI Test 진행 후 추가 수정사항과 함께 같이 머지 하겠습니다.

### Discuss
---
- 휴일 관련해서는 레퍼런스를 이용하였습니다. 아래 레퍼런스 주소 참조하겠습니다!

### Reference
---
- [공휴일 계산](http://kimstar.kr/6881/)
