### PR TITLE
Fix : Front 통합 테스트 관련 오류 수정

### DIFF
--- a/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/AuthErrorCode.java
@@ -18,6 +18,7 @@ public enum AuthErrorCode {
     AccessTokenAlreadyExpired(HttpStatus.UNAUTHORIZED, "인증이 만료되었습니다. 다시 로그인해주세요."),
     TokenNotMatch(HttpStatus.CONFLICT, "토큰이 일치하지 않습니다."),
     AuthKeyNotMatch(HttpStatus.CONFLICT, "인증 코드가 맞지 않습니다."),
+    AlreadyStopMember(HttpStatus.BAD_REQUEST, "회원탈퇴가 완료된 아이디입니다."),
     OAuthProviderMissMatch(HttpStatus.BAD_REQUEST, "기존에 회원가입한 소셜 타입과 일치하지 않습니다.");
 
     private final HttpStatus statusCode;

--- a/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
+++ b/src/main/java/com/minwonhaeso/esc/error/type/StadiumErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum StadiumErrorCode {
     StadiumNotFound(HttpStatus.BAD_REQUEST, "일치하는 체육관 정보가 존재하지 않습니다."),
     ReservationNotFound(HttpStatus.BAD_REQUEST, "일치하는 예약 정보가 존재하지 않습니다."),
+    HasReservation(HttpStatus.BAD_REQUEST, "예약 정보가 존재합니다."),
     ItemNotFound(HttpStatus.BAD_REQUEST, "일치하는 아이템 정보가 존재하지 않습니다."),
     StadiumReservationNotMatch(HttpStatus.BAD_REQUEST, "해당 체육관에 존재하는 예약이 아닙니다."),
     UnAuthorizedAccess(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -3,6 +3,7 @@ package com.minwonhaeso.esc.member.controller;
 import com.minwonhaeso.esc.member.model.dto.CPasswordDto;
 import com.minwonhaeso.esc.member.model.dto.InfoDto;
 import com.minwonhaeso.esc.member.model.dto.PatchInfo;
+import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.member.service.MemberService;
 import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import io.swagger.annotations.ApiOperation;
@@ -25,8 +26,9 @@ public class MemberProfileController {
      **/
     @ApiOperation(value = "회원 상세 정보", notes = "회원 정보 페이지에 필요한 상세 정보를 보여줍니다.")
     @PostMapping("/info")
-    public ResponseEntity<InfoDto.Response> info(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(memberService.info(userDetails));
+    public ResponseEntity<InfoDto.Response> info(@AuthenticationPrincipal PrincipalDetail principalDetail) {
+        Member member = principalDetail.getMember();
+        return ResponseEntity.ok(memberService.info(member));
     }
 
     /**
@@ -34,9 +36,10 @@ public class MemberProfileController {
      **/
     @ApiOperation(value = "회원 정보 수정", notes = "프로필 사진과 닉네임 정보를 수정합니다.")
     @PatchMapping("/info")
-    public ResponseEntity<PatchInfo.Request> patchInfo(@AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<PatchInfo.Request> patchInfo(@AuthenticationPrincipal PrincipalDetail principalDetail,
                                                        @RequestBody PatchInfo.Request request) {
-        return ResponseEntity.ok(memberService.patchInfo(userDetails, request));
+        Member member = principalDetail.getMember();
+        return ResponseEntity.ok(memberService.patchInfo(member, request));
     }
 
     /**
@@ -44,8 +47,9 @@ public class MemberProfileController {
      **/
     @ApiOperation(value = "회원 탈퇴", notes = "해당 서비스를 탈퇴합니다.")
     @DeleteMapping("/info")
-    public ResponseEntity<Map<String, String>> delete(@AuthenticationPrincipal PrincipalDetail userDetails) {
-        Map<String, String> result = memberService.deleteMember(userDetails);
+    public ResponseEntity<Map<String, String>> delete(@AuthenticationPrincipal PrincipalDetail principalDetail) {
+        Member member = principalDetail.getMember();
+        Map<String, String> result = memberService.deleteMember(member);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
+++ b/src/main/java/com/minwonhaeso/esc/member/controller/MemberProfileController.java
@@ -4,6 +4,7 @@ import com.minwonhaeso.esc.member.model.dto.CPasswordDto;
 import com.minwonhaeso.esc.member.model.dto.InfoDto;
 import com.minwonhaeso.esc.member.model.dto.PatchInfo;
 import com.minwonhaeso.esc.member.service.MemberService;
+import com.minwonhaeso.esc.security.auth.PrincipalDetail;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +44,7 @@ public class MemberProfileController {
      **/
     @ApiOperation(value = "회원 탈퇴", notes = "해당 서비스를 탈퇴합니다.")
     @DeleteMapping("/info")
-    public ResponseEntity<Map<String, String>> delete(@AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<Map<String, String>> delete(@AuthenticationPrincipal PrincipalDetail userDetails) {
         Map<String, String> result = memberService.deleteMember(userDetails);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
+++ b/src/main/java/com/minwonhaeso/esc/member/service/MemberService.java
@@ -59,7 +59,7 @@ public class MemberService {
         MemberEmail memberEmail = memberEmailRepository.findById(signDto.getKey()).orElseThrow(
                 ()-> new AuthException(AuthKeyNotMatch));
         if(!memberEmail.getEmail().equals(signDto.getEmail())){
-            throw new AuthException(EmailNotMatched);
+            throw new AuthException(AuthKeyNotMatch);
         }
         signDto.setPassword(passwordEncoder.encode(signDto.getPassword()));
         Member member = Member.of(signDto);
@@ -98,12 +98,8 @@ public class MemberService {
     }
 
     public Map<String, String> emailAuthentication(String key) {
-        MemberEmail memberEmail = memberEmailRepository.findById(key).orElseThrow(
-                () -> new AuthException(EmailAuthTimeOut));
-        memberEmailRepository.save(memberEmail);
-        if (!memberEmail.getId().equals(key)) {
-            throw new AuthException(AuthKeyNotMatch);
-        }
+        memberEmailRepository.findById(key).orElseThrow(
+                () -> new AuthException(AuthKeyNotMatch));
         return successMessage("메일 인증이 완료되었습니다.");
     }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -14,6 +14,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RequiredArgsConstructor
 @RestController
@@ -33,10 +35,10 @@ public class StadiumLikeController {
 
     @ApiOperation(value = "찜한 리스트", notes = "접속한 유저가 찜한 체육관 리스트를 보여줍니다.")
     @GetMapping("/likelist")
-    public ResponseEntity<Page<StadiumLikeResponseDto>> likeList(@AuthenticationPrincipal PrincipalDetail principalDetail,
+    public ResponseEntity<List<StadiumLikeResponseDto>> likeList(@AuthenticationPrincipal PrincipalDetail principalDetail,
                                       Pageable pageable){
         Member member = principalDetail.getMember();
-        Page<StadiumLikeResponseDto> likes = stadiumLikeService.likeList(member,pageable);
+        List<StadiumLikeResponseDto> likes = stadiumLikeService.likeList(member,pageable);
         return ResponseEntity.ok(likes);
     }
 

--- a/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/controller/StadiumLikeController.java
@@ -31,7 +31,7 @@ public class StadiumLikeController {
         return ResponseEntity.ok(stadiumLikeService.likes(stadiumId, member));
     }
 
-    @ApiOperation(value = "찜하기 리스트", notes = "접속한 유저가 찜한 체육관 리스트를 보여줍니다.")
+    @ApiOperation(value = "찜한 리스트", notes = "접속한 유저가 찜한 체육관 리스트를 보여줍니다.")
     @GetMapping("/likelist")
     public ResponseEntity<Page<StadiumLikeResponseDto>> likeList(@AuthenticationPrincipal PrincipalDetail principalDetail,
                                       Pageable pageable){

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.minwonhaeso.esc.stadium.model.type.StadiumStatus.*;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,7 +27,10 @@ public class StadiumLikeResponseDto {
 
     public static StadiumLikeResponseDto fromEntity(StadiumLike stadiumLike) {
         Stadium stadium = stadiumLike.getStadium();
-
+        if (stadium.getStatus() == DELETED
+                || stadium.getStatus() == BANNED) {
+            return null;
+        }
         return StadiumLikeResponseDto.builder()
                 .stadiumId(stadium.getId())
                 .name(stadium.getName())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumLikeResponseDto.java
@@ -27,10 +27,6 @@ public class StadiumLikeResponseDto {
 
     public static StadiumLikeResponseDto fromEntity(StadiumLike stadiumLike) {
         Stadium stadium = stadiumLike.getStadium();
-        if (stadium.getStatus() == DELETED
-                || stadium.getStatus() == BANNED) {
-            return null;
-        }
         return StadiumLikeResponseDto.builder()
                 .stadiumId(stadium.getId())
                 .name(stadium.getName())

--- a/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumPaymentDto.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/model/dto/StadiumPaymentDto.java
@@ -1,10 +1,7 @@
 package com.minwonhaeso.esc.stadium.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,8 +10,11 @@ import java.util.List;
 @Builder
 public class StadiumPaymentDto {
 
-    @Data
+    @Getter
+    @Setter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class PaymentRequest {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         private LocalDate date;
@@ -26,7 +26,8 @@ public class StadiumPaymentDto {
         private String paymentType;
     }
 
-    @Data
+    @Getter
+    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
@@ -17,5 +17,6 @@ public interface StadiumRepository extends JpaRepository<Stadium, Long> {
     @Override
     Page<Stadium> findAll(Pageable pageable);
     Page<Stadium> findByMember(Member member, Pageable pageable);
+    List<Stadium> findByMember(Member member);
 
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepository.java
@@ -17,6 +17,6 @@ public interface StadiumRepository extends JpaRepository<Stadium, Long> {
     @Override
     Page<Stadium> findAll(Pageable pageable);
     Page<Stadium> findByMember(Member member, Pageable pageable);
-    List<Stadium> findByMember(Member member);
+    List<Stadium> findAllByMember(Member member);
 
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepositorySupport.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumRepositorySupport.java
@@ -1,6 +1,7 @@
 package com.minwonhaeso.esc.stadium.repository;
 
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import com.minwonhaeso.esc.stadium.model.type.StadiumStatus;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.minwonhaeso.esc.stadium.model.entity.QStadium.stadium;
+import static com.minwonhaeso.esc.stadium.model.entity.QStadiumLike.stadiumLike;
 
 @Repository
 public class StadiumRepositorySupport extends QuerydslRepositorySupport {
@@ -31,5 +33,14 @@ public class StadiumRepositorySupport extends QuerydslRepositorySupport {
                         Expressions.stringTemplate("POINT({0}, {1})", lnt, lat),
                         Expressions.stringTemplate("POINT({0}, {1})", stadium.lnt, stadium.lat)
                 ).asc()).fetch();
+    }
+    public List<StadiumLike> getAllAvailableLikeStadium(Long memberId,Pageable pageable){
+        return queryFactory
+                .selectFrom(stadiumLike)
+                .where(stadiumLike.stadium.status.eq(StadiumStatus.AVAILABLE))
+                .where(stadiumLike.member.memberId.eq(memberId))
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
     }
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/repository/StadiumReservationRepository.java
@@ -20,4 +20,6 @@ public interface StadiumReservationRepository extends JpaRepository<StadiumReser
             Member member, LocalDate reservingDate, Pageable pageable);
     List<StadiumReservation> findAllByStadiumAndReservingDate(Stadium stadium, LocalDate reservingDate);
     Long countAllByMemberAndStadiumAndStatusIs(Member member, Stadium stadium, StadiumReservationStatus status);
+
+    List<StadiumReservation> findALlByMember(Member member);
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumLikeService.java
@@ -9,23 +9,29 @@ import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.entity.StadiumLike;
 import com.minwonhaeso.esc.stadium.repository.StadiumLikeRepository;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepositorySupport;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.minwonhaeso.esc.error.type.StadiumErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 public class StadiumLikeService {
     private final StadiumLikeRepository stadiumLikeRepository;
+    private final StadiumRepositorySupport stadiumRepositorySupport;
     private final StadiumRepository stadiumRepository;
 
     public StadiumLikeRequestDto likes(Long stadiumId, Member member) {
         Stadium stadium = stadiumRepository.findById(stadiumId)
-                .orElseThrow(() -> new StadiumException(StadiumErrorCode.StadiumNotFound));
+                .orElseThrow(() -> new StadiumException(StadiumNotFound));
         Optional<StadiumLike> optionalLike = stadiumLikeRepository.findByMemberAndStadium(member, stadium);
         StadiumLikeRequestDto dto = new StadiumLikeRequestDto();
         if (optionalLike.isEmpty()){
@@ -41,7 +47,9 @@ public class StadiumLikeService {
         return dto;
     }
     @Transactional(readOnly = true)
-    public Page<StadiumLikeResponseDto> likeList(Member member, Pageable pageable) {
-        return stadiumLikeRepository.findAllByMember(member,pageable).map(StadiumLikeResponseDto::fromEntity);
+    public List<StadiumLikeResponseDto> likeList(Member member, Pageable pageable) {
+        return stadiumRepositorySupport.getAllAvailableLikeStadium(member.getMemberId(), pageable)
+                .stream().map(StadiumLikeResponseDto::fromEntity).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumPaymentService.java
+++ b/src/main/java/com/minwonhaeso/esc/stadium/service/StadiumPaymentService.java
@@ -62,13 +62,15 @@ public class StadiumPaymentService {
                 try {
                     StadiumItem stadiumItem = stadiumItemRepository.findById(item.getId())
                             .orElseThrow(() -> new StadiumException(ItemNotFound));
-
-                    items.add(StadiumReservationItem.builder()
+                    StadiumReservationItem reservationItem =   StadiumReservationItem.builder()
                             .item(stadiumItem)
                             .count(item.getCount())
                             .reservation(reservation)
                             .price(item.getCount() * stadiumItem.getPrice())
-                            .build());
+                            .build();
+                    if(reservationItem.getCount() !=0) {
+                        items.add(reservationItem);
+                    }
                 } catch (StadiumException e) {
                     log.info("item not found. id:" + item.getId());
                 }

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceTest.java
@@ -1,0 +1,317 @@
+package com.minwonhaeso.esc.member.service;
+
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
+import com.minwonhaeso.esc.mail.MailService;
+import com.minwonhaeso.esc.member.model.dto.LoginDto;
+import com.minwonhaeso.esc.member.model.dto.SignDto;
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.model.entity.MemberEmail;
+import com.minwonhaeso.esc.member.model.type.MemberType;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.member.repository.redis.MemberEmailRepository;
+import com.minwonhaeso.esc.security.auth.redis.LogoutAccessTokenRedisRepository;
+import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
+import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
+import com.minwonhaeso.esc.util.JwtTokenUtil;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @InjectMocks
+    public MemberService memberService;
+
+    @Mock
+    public MemberRepository memberRepository;
+
+    @Mock
+    public MailService mailService;
+    @Mock
+    public PasswordEncoder passwordEncoder;
+    @Mock
+    public MemberEmailRepository memberEmailRepository;
+    @Mock
+    public RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Mock
+    public LogoutAccessTokenRedisRepository logoutAccessTokenRedisRepository;
+    @Mock
+    public JwtTokenUtil jwtTokenUtil;
+    @Mock
+    public StadiumRepository stadiumRepository;
+    @Mock
+    public StadiumReservationRepository stadiumReservationRepository;
+
+    @Before("")
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        memberService = new MemberService(memberRepository, passwordEncoder, mailService, memberEmailRepository,
+                refreshTokenRedisRepository, logoutAccessTokenRedisRepository, jwtTokenUtil, stadiumRepository, stadiumReservationRepository);
+    }
+
+
+    @DisplayName("이메일 중복확인 성공")
+    @Test
+    void emailDuplicate_Success() {
+        String email = "ESC@gmail.com";
+        //given
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
+        //when
+        Map<String, String> result = memberService.emailDuplicateYn(email);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @DisplayName("이메일 중복확인 실패 - 존재하는 이메일")
+    @Test
+    void emailDuplicate_Fail() {
+        String email = "ESC@gmail.com";
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+        //when
+        AuthException exception = assertThrows(AuthException.class,
+                () -> memberService.emailDuplicateYn(email));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.EmailAlreadySignUp);
+    }
+
+    @DisplayName("이메일 코드 인증 - 성공")
+    @Test
+    void emailAuthentication_Success() {
+        String key = "111111";
+        MemberEmail memberEmail = MemberEmail.builder()
+                .email("test@gmail.com")
+                .expireDt(100L)
+                .id(key)
+                .build();
+
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.of(memberEmail));
+        //when
+        Map<String, String> result = memberService.emailAuthentication(key);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @DisplayName("이메일 코드 인증 실패 - 코드 번호가 다름")
+    @Test
+    void emailAuthentication_Fail_CodeNotMatch() {
+        String key = "111111";
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        AuthException exception = assertThrows(AuthException.class, () -> memberService.emailAuthentication(key));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.AuthKeyNotMatch);
+    }
+
+    @DisplayName("회원가입 실패 - 인증 키가 맞지 않습니다.")
+    @Test
+    void signUser_Fail() {
+        String key = "123456";
+
+        SignDto.Request request = SignDto.Request.builder()
+                .type("USER")
+                .email("test@gmail.com")
+                .name("ESC")
+                .password("1234")
+                .nickname("TEST")
+                .image("https:/ESC/image")
+                .key(key)
+                .build();
+
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        AuthException exception = assertThrows(AuthException.class, () -> memberService.signUser(request));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.AuthKeyNotMatch);
+    }
+
+    @DisplayName("회원가입 실패 - 인증 키 값이 일치하지 않습니다.(다른 사람이 발급한 코드)")
+    @Test
+    void signUser_Fail_EmailNotMatch() {
+        String key = "123456";
+        SignDto.Request request = SignDto.Request.builder()
+                .type("USER")
+                .email("test@gmail.com")
+                .name("ESC")
+                .password("1234")
+                .nickname("TEST")
+                .image("https:/ESC/image")
+                .key(key)
+                .build();
+        //given
+        //when
+        AuthException exception = assertThrows(AuthException.class, () -> memberService.signUser(request));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.AuthKeyNotMatch);
+    }
+
+    @DisplayName("회원가입 - 성공")
+    @Test
+    void signUser_Success() {
+        String key = "123456";
+        MemberEmail memberEmail = MemberEmail.builder()
+                .email("test@gmail.com")
+                .expireDt(100L)
+                .id("123456")
+                .build();
+        SignDto.Request request = SignDto.Request.builder()
+                .type("USER")
+                .email("test@gmail.com")
+                .name("ESC")
+                .password("1234")
+                .nickname("TEST")
+                .image("https:/ESC/image")
+                .key(key)
+                .build();
+        String password = "akjldsfajwnl;kfsnf;wa";
+
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.of(memberEmail));
+        given(passwordEncoder.encode(anyString()))
+                .willReturn(password);
+        //when
+        SignDto.Response response = memberService.signUser(request);
+        //then
+        assertEquals(response.getNickname(), request.getNickname());
+    }
+
+    @DisplayName("로그인 성공")
+    @Test
+    void login_Success() {
+        LoginDto.Request request = LoginDto.Request.builder()
+                .email("test@gmail.com")
+                .password("1111")
+                .type("USER")
+                .build();
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        String password = "akjldsfajwnl;kfsnf;wa";
+        String accessToken = "asdf.asdf.asdf";
+        RefreshToken refreshToken = RefreshToken.builder()
+                .id("test@gmail.com")
+                .refreshToken("fdsa.fdsa.fdsa")
+                .expiration(100L).build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(), anyString()))
+                .willReturn(true);
+        given(jwtTokenUtil.generateAccessToken(anyString()))
+                .willReturn(accessToken);
+        given(jwtTokenUtil.saveRefreshToken(anyString()))
+                .willReturn(refreshToken);
+        //when
+        LoginDto.Response response = memberService.login(request);
+        //then
+        assertEquals(refreshToken.getRefreshToken(), response.getRefreshToken());
+    }
+
+    @DisplayName("로그인 실패 - 일치하는 회원이 없습니다,")
+    @Test
+    void login_Fail_MemberNotFound() {
+        LoginDto.Request request = LoginDto.Request.builder()
+                .email("test@gmail.com")
+                .password("1111")
+                .type("USER")
+                .build();
+
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        AuthException exception = assertThrows(AuthException.class, () -> memberService.login(request));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.MemberNotFound);
+    }
+
+    @DisplayName("로그인 실패 - 회원가입한 타입과 다르게 로그인함")
+    @Test
+    void login_Fail_MemberTypeNotMatch() {
+        LoginDto.Request request = LoginDto.Request.builder()
+                .email("test@gmail.com")
+                .password("1111")
+                .type("MANAGER")
+                .build();
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .type(MemberType.USER)
+                .build();
+
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(),anyString()))
+                .willReturn(true);
+        //when
+        AuthException exception = assertThrows(AuthException.class, ()-> memberService.login(request));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.MemberTypeNotMatch);
+    }
+
+    @DisplayName("로그인 실패 - 패스워드를 다시 입력해주세요.")
+    @Test
+    void login_Fail_PasswordNotEqual() {
+        LoginDto.Request request = LoginDto.Request.builder()
+                .email("test@gmail.com")
+                .password("1111")
+                .type("MANAGER")
+                .build();
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .type(MemberType.USER)
+                .build();
+
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        //when
+        AuthException exception = assertThrows(AuthException.class, ()-> memberService.login(request));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.PasswordNotEqual);
+    }
+
+
+
+}

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
@@ -1,21 +1,49 @@
 package com.minwonhaeso.esc.member.service;
 
 
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.exception.StadiumException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
+import com.minwonhaeso.esc.error.type.StadiumErrorCode;
 import com.minwonhaeso.esc.mail.MailService;
+import com.minwonhaeso.esc.member.model.dto.CPasswordDto;
+import com.minwonhaeso.esc.member.model.dto.InfoDto;
+import com.minwonhaeso.esc.member.model.dto.PatchInfo;
+import com.minwonhaeso.esc.member.model.dto.TokenDto;
+import com.minwonhaeso.esc.member.model.entity.Member;
+import com.minwonhaeso.esc.member.model.entity.MemberEmail;
+import com.minwonhaeso.esc.member.model.type.MemberType;
 import com.minwonhaeso.esc.member.repository.MemberRepository;
 import com.minwonhaeso.esc.member.repository.redis.MemberEmailRepository;
 import com.minwonhaeso.esc.security.auth.redis.LogoutAccessTokenRedisRepository;
+import com.minwonhaeso.esc.security.auth.redis.RefreshToken;
 import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import com.minwonhaeso.esc.stadium.model.entity.Stadium;
+import com.minwonhaeso.esc.stadium.model.entity.StadiumReservation;
+import com.minwonhaeso.esc.stadium.model.type.PaymentType;
+import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
+import com.minwonhaeso.esc.stadium.model.type.StadiumReservationStatus;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
 import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
 import com.minwonhaeso.esc.util.JwtTokenUtil;
 import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceWithPrincipalTest {
@@ -49,4 +77,423 @@ class MemberServiceWithPrincipalTest {
                 refreshTokenRedisRepository, logoutAccessTokenRedisRepository, jwtTokenUtil, stadiumRepository, stadiumReservationRepository);
     }
 
+    @DisplayName("로그아웃 성공")
+    @Test
+    void logout(){
+        String userName = "test@gmail.com";
+        TokenDto tokenDto = TokenDto.builder()
+                .accessToken("asdf.asdf.asdf")
+                .refreshToken("fdsa.fdsa.fdsa")
+                .grantType("ROLE_USER")
+                .build();
+        //given
+
+        //when
+        Map<String, String> result =  memberService.logout(tokenDto, userName);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @Test
+    void reissue_Success(){
+        String refreshToken = "Bearer asdf.asdf.asdf";
+        String newAccessToken = "Bearer qwer.qwer.qwer";
+        RefreshToken token = RefreshToken.builder()
+                .id("test@gmail.com")
+                .refreshToken("asdf.asdf.asdf")
+                .expiration(100L)
+                .build();
+        //given
+        given(jwtTokenUtil.getUsername(anyString())).willReturn("test@gmail.com");
+        given(refreshTokenRedisRepository.findById(anyString()))
+                .willReturn(Optional.of(token));
+        given(jwtTokenUtil.generateAccessToken(anyString()))
+                .willReturn(newAccessToken);
+        given(jwtTokenUtil.saveRefreshToken(anyString()))
+                .willReturn(token);
+
+        //when
+        TokenDto result =  memberService.reissue(refreshToken);
+        //then
+        assertNotNull(result.getAccessToken());
+    }
+
+    @Test
+    void reissue_Fail_AccessTokenAlreadyExpired(){
+        String refreshToken = "Bearer asdf.asdf.asdf";
+        //given
+        given(jwtTokenUtil.getUsername(anyString())).willReturn("test@gmail.com");
+        given(refreshTokenRedisRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        AuthException exception = assertThrows(AuthException.class,
+                ()->  memberService.reissue(refreshToken));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.AccessTokenAlreadyExpired);
+    }
+
+    @Test
+    void reissue_Fail_RefreshTokenNotMatch(){
+        String refreshToken = "Bearer asdf.asdf.asdf";
+        String newAccessToken = "Bearer qwer.qwer.qwer";
+        RefreshToken token = RefreshToken.builder()
+                .id("test@gmail.com")
+                .refreshToken("asdf.asdf.asdf2")
+                .expiration(100L)
+                .build();
+        //given
+        given(jwtTokenUtil.getUsername(anyString())).willReturn("test@gmail.com");
+        given(refreshTokenRedisRepository.findById(anyString()))
+                .willReturn(Optional.of(token));
+
+        //when
+        AuthException exception = assertThrows(AuthException.class,
+                ()-> memberService.reissue(refreshToken));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.TokenNotMatch);
+    }
+
+    @Test
+    void getInfo_Success(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .build();
+        //given
+
+        //when
+        InfoDto.Response result =  memberService.info(member);
+        //then
+        assertEquals(member.getMemberId(), result.getId());
+    }
+
+    @Test
+    void getPatch(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .build();
+        PatchInfo.Request request = PatchInfo.Request.builder()
+                .nickname("뽀로로")
+                .imgUrl("house")
+                .build();
+        //given
+
+        //when
+        PatchInfo.Request result =  memberService.patchInfo(member,request);
+        //then
+        assertEquals(result.getNickname(), request.getNickname());
+    }
+
+    @Test
+    void deleteMember_Success_Type_User(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        List<StadiumReservation> reservations = new ArrayList<>();
+        //given
+        given(stadiumReservationRepository.findALlByMember(member))
+                .willReturn(reservations);
+        //when
+        Map<String, String> result =  memberService.deleteMember(member);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @Test
+    void deleteMember_Success_Type_Manager(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.MANAGER)
+                .build();
+        List<Stadium> stadiums = new ArrayList<>();
+        //given
+        given(stadiumRepository.findAllByMember(member))
+                .willReturn(stadiums);
+
+        //when
+        Map<String, String> result =  memberService.deleteMember(member);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @Test
+    void deleteMember_Fail_HasReservation_Manager(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.MANAGER)
+                .build();
+        List<StadiumReservation> reservations = new ArrayList<>();
+        reservations.add(new StadiumReservation());
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.RT19)
+                .closeTime(ReservingTime.RT37)
+                .reservations(reservations)
+                .build();
+        List<Stadium> stadiums = new ArrayList<>();
+        stadiums.add(stadium);
+        //given
+        given(stadiumRepository.findAllByMember(member))
+                .willReturn(stadiums);
+        //when
+        StadiumException exception = assertThrows(StadiumException.class, ()-> memberService.deleteMember(member));
+        //then
+        assertEquals(exception.getErrorCode(), StadiumErrorCode.HasReservation);
+    }
+
+    @Test
+    void deleteMember_Fail_User(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        StadiumReservation reservation = StadiumReservation.builder()
+                .id(1L)
+                .paymentType(PaymentType.CARD)
+                .status(StadiumReservationStatus.RESERVED)
+                .headCount(2)
+                .price(10000)
+                .build();
+
+        List<StadiumReservation> reservations = new ArrayList<>();
+        reservations.add(reservation);
+        //given
+        given(stadiumReservationRepository.findALlByMember(member))
+                .willReturn(reservations);
+        //when
+        StadiumException exception = assertThrows(StadiumException.class, ()-> memberService.deleteMember(member));
+        //then
+        assertEquals(exception.getErrorCode(), StadiumErrorCode.HasReservation);
+    }
+
+    @Test
+    void changePasswordMailAuth_Success(){
+        String key = "12312434132123";
+        MemberEmail memberEmail = MemberEmail.builder()
+                .id(key)
+                .email("phc09188@gmail.com")
+                .expireDt(100L)
+                .build();
+
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.of(memberEmail));
+        //when
+        Map<String,String> result = memberService.changePasswordMailAuth(key);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @Test
+    void changePasswordMailAuth_Fail_EmailAuthTimeOut(){
+        String key = "12312434132123";
+
+
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.empty());
+        //when
+        AuthException exception = assertThrows(AuthException.class,
+                () -> memberService.changePasswordMailAuth(key));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.EmailAuthTimeOut);
+    }
+    @Test
+    void changePasswordMailAuth_Fail_AuthKeyNotMatch(){
+        String key = "12312434132123";
+        MemberEmail memberEmail = MemberEmail.builder()
+                .id(key +"1111")
+                .email("phc09188@gmail.com")
+                .expireDt(100L)
+                .build();
+        //given
+        given(memberEmailRepository.findById(anyString()))
+                .willReturn(Optional.of(memberEmail));
+        //when
+        AuthException exception = assertThrows(AuthException.class,
+                () -> memberService.changePasswordMailAuth(key));
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.AuthKeyNotMatch);
+    }
+
+    @Test
+    void changePassword_HasNotToken_Success(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email("ESC@gmail.com")
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("1234")
+                .hasToken(false)
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.encode(anyString())).willReturn("asdf");
+        //when
+        Map<String, String> result = memberService.changePassword(request);
+        //then
+        assertNotNull(result.get("message"));
+    }
+
+    @Test
+    void changePassword_HasToken_Success(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email("ESC@gmail.com")
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("1234")
+                .hasToken(true)
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(), anyString()))
+                .willReturn(true);
+        given(passwordEncoder.encode(anyString())).willReturn("asdf");
+        //when
+        Map<String, String> result = memberService.changePassword(request);
+        //then
+        assertNotNull(result.get("message"));
+    }
+    @Test
+    void changePassword_HasNotToken_Fail_PasswordNotEqual(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email("ESC@gmail.com")
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("12345")
+                .hasToken(false)
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        //when
+        AuthException exception = assertThrows(AuthException.class,() -> memberService.changePassword(request));
+
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.PasswordNotEqual);
+    }
+    @Test
+    void changePassword_HasToken_Fail_PasswordNotEqual1(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email("ESC@gmail.com")
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("12345")
+                .hasToken(true)
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(), anyString()))
+                .willReturn(false);
+        //when
+        AuthException exception = assertThrows(AuthException.class,() -> memberService.changePassword(request));
+
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.PasswordNotEqual);
+    }
+    @Test
+    void changePassword_HasToken_Fail_PasswordNotEqual2(){
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .nickname("제로로")
+                .imgUrl("https:/ESC/kadfl")
+                .password("1111")
+                .email("ESC@gmail.com")
+                .type(MemberType.USER)
+                .build();
+        CPasswordDto.Request request = CPasswordDto.Request.builder()
+                .email("ESC@gmail.com")
+                .prePassword("1111")
+                .newPassword("1234")
+                .confirmPassword("12345")
+                .hasToken(true)
+                .build();
+        //given
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+        given(passwordEncoder.matches(anyString(), anyString()))
+                .willReturn(true);
+        //when
+        AuthException exception = assertThrows(AuthException.class,() -> memberService.changePassword(request));
+
+        //then
+        assertEquals(exception.getErrorCode(), AuthErrorCode.PasswordNotEqual);
+    }
 }

--- a/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
+++ b/src/test/java/com/minwonhaeso/esc/member/service/MemberServiceWithPrincipalTest.java
@@ -1,0 +1,52 @@
+package com.minwonhaeso.esc.member.service;
+
+
+import com.minwonhaeso.esc.mail.MailService;
+import com.minwonhaeso.esc.member.repository.MemberRepository;
+import com.minwonhaeso.esc.member.repository.redis.MemberEmailRepository;
+import com.minwonhaeso.esc.security.auth.redis.LogoutAccessTokenRedisRepository;
+import com.minwonhaeso.esc.security.auth.redis.RefreshTokenRedisRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
+import com.minwonhaeso.esc.util.JwtTokenUtil;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceWithPrincipalTest {
+    @InjectMocks
+    public MemberService memberService;
+
+    @Mock
+    public MemberRepository memberRepository;
+
+    @Mock
+    public MailService mailService;
+    @Mock
+    public PasswordEncoder passwordEncoder;
+    @Mock
+    public MemberEmailRepository memberEmailRepository;
+    @Mock
+    public RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Mock
+    public LogoutAccessTokenRedisRepository logoutAccessTokenRedisRepository;
+    @Mock
+    public JwtTokenUtil jwtTokenUtil;
+    @Mock
+    public StadiumRepository stadiumRepository;
+    @Mock
+    public StadiumReservationRepository stadiumReservationRepository;
+
+    @Before("")
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        memberService = new MemberService(memberRepository, passwordEncoder, mailService, memberEmailRepository,
+                refreshTokenRedisRepository, logoutAccessTokenRedisRepository, jwtTokenUtil, stadiumRepository, stadiumReservationRepository);
+    }
+
+}

--- a/src/test/java/com/minwonhaeso/esc/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/review/service/ReviewServiceTest.java
@@ -14,7 +14,6 @@ import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
 import com.minwonhaeso.esc.stadium.repository.StadiumReservationRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,38 +52,18 @@ class ReviewServiceTest {
     @InjectMocks
     private ReviewService reviewService;
 
-    private Member member;
-    private Stadium stadium;
-    private final Long stadiumId = 1L;
-    private final Long reviewId = 1L;
+    @Test
+    @DisplayName("리뷰 작성 실패 - 존재하지 않는 체육관")
+    void createReviewFail_StadiumNotFound() {
+        Long stadiumId = 1L;
 
-    @BeforeEach
-    void beforeEach() {
-        member = Member.builder()
+        Member member = Member.builder()
                 .memberId(1L)
                 .name("제로")
                 .password("1111")
                 .email("test@gmail.com")
                 .build();
 
-        stadium = Stadium.builder()
-                .id(1L)
-                .name("ESC 체육관")
-                .phone("010-1234-5678")
-                .address("경기도 광교")
-                .detailAddress("123-456")
-                .lat(36.5)
-                .lnt(127.5)
-                .weekdayPricePerHalfHour(19000)
-                .holidayPricePerHalfHour(25000)
-                .openTime(ReservingTime.findTime("09:00"))
-                .closeTime(ReservingTime.findTime("18:00"))
-                .build();
-    }
-
-    @Test
-    @DisplayName("리뷰 작성 실패 - 존재하지 않는 체육관")
-    void createReviewFail_StadiumNotFound() {
         ReviewDto.Request request = ReviewDto.Request.builder()
                 .star(4.0)
                 .comment("쾌적합니다")
@@ -106,6 +85,29 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 작성 실패 - 존재하지 않는 체육관 사용 내역")
     void createReviewFail_NoReservationForReview() {
+        Long stadiumId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         ReviewDto.Request request = ReviewDto.Request.builder()
                 .star(4.0)
                 .comment("쾌적합니다")
@@ -130,6 +132,29 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 작성 실패 - 리뷰 작성 가능 횟수 초과")
     void createReviewFail_ReviewCountOverReservation() {
+        Long stadiumId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         ReviewDto.Request request = ReviewDto.Request.builder()
                 .star(4.0)
                 .comment("쾌적합니다")
@@ -157,6 +182,30 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 삭제 성공")
     void deleteReviewSuccess() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         Review review = Review.builder()
                 .star(4.0)
                 .comment("쾌적합니다")
@@ -184,6 +233,16 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 삭제 실패 - 존재하지 않는 체육관")
     void deleteReviewFail_StadiumNotFound() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
         // given
         given(stadiumRepository.findById(anyLong()))
                 .willReturn(Optional.empty());
@@ -200,6 +259,30 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 삭제 실패 - 존재하지 않는 리뷰")
     void deleteReviewFail_ReviewNotFound() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         // given
         given(stadiumRepository.findById(anyLong()))
                 .willReturn(Optional.of(stadium));
@@ -219,11 +302,35 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 삭제 실패 - 리뷰 작성자 미일치")
     void deleteReviewFail_UnAuthorizedAccess() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
         Member member1 = Member.builder()
                 .memberId(2L)
                 .name("제로1")
                 .password("1111")
                 .email("test1@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
                 .build();
 
         Review review = Review.builder()
@@ -251,6 +358,30 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 수정 성공")
     void updateReviewSuccess() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         Review review = Review.builder()
                 .id(1L)
                 .star(4.0)
@@ -284,6 +415,16 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 수정 실패 - 존재하지 않는 체육관")
     void updateReviewFail_StadiumNotFound() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
         ReviewDto.Request request = ReviewDto.Request.builder()
                 .star(3.0)
                 .comment("시설이 제대로 관리되는 것 같지 않습니다")
@@ -305,6 +446,30 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 수정 실패 - 존재하지 않는 리뷰")
     void updateReviewFail_ReviewNotFound() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
+                .build();
+
         ReviewDto.Request request = ReviewDto.Request.builder()
                 .star(3.0)
                 .comment("시설이 제대로 관리되는 것 같지 않습니다")
@@ -329,11 +494,35 @@ class ReviewServiceTest {
     @Test
     @DisplayName("리뷰 수정 실패 - 리뷰 작성자 미일치")
     void updateReviewFail_UnAuthorizedAccess() {
+        Long stadiumId = 1L;
+        Long reviewId = 1L;
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+
         Member member1 = Member.builder()
                 .memberId(2L)
                 .name("제로1")
                 .password("1111")
                 .email("test1@gmail.com")
+                .build();
+
+        Stadium stadium = Stadium.builder()
+                .id(1L)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.findTime("09:00"))
+                .closeTime(ReservingTime.findTime("18:00"))
                 .build();
 
         Review review = Review.builder()

--- a/src/test/java/com/minwonhaeso/esc/stadium/service/StadiumLikeServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/stadium/service/StadiumLikeServiceTest.java
@@ -8,6 +8,7 @@ import com.minwonhaeso.esc.stadium.model.entity.Stadium;
 import com.minwonhaeso.esc.stadium.model.type.ReservingTime;
 import com.minwonhaeso.esc.stadium.repository.StadiumLikeRepository;
 import com.minwonhaeso.esc.stadium.repository.StadiumRepository;
+import com.minwonhaeso.esc.stadium.repository.StadiumRepositorySupport;
 import org.aspectj.lang.annotation.Before;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,12 +34,14 @@ class StadiumLikeServiceTest {
     public StadiumLikeRepository stadiumLikeRepository;
     @Mock
     public StadiumRepository stadiumRepository;
+    @Mock
+    public StadiumRepositorySupport stadiumRepositorySupport;
 
 
     @Before("")
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        stadiumLikeService = new StadiumLikeService(stadiumLikeRepository, stadiumRepository);
+        stadiumLikeService = new StadiumLikeService(stadiumLikeRepository, stadiumRepositorySupport, stadiumRepository);
     }
 
     @Test
@@ -92,48 +95,6 @@ class StadiumLikeServiceTest {
         assertEquals(exception.getErrorCode(), StadiumErrorCode.StadiumNotFound);
     }
 
-//    /* list단위 테스트는 컨트롤러 테스트 코드에서 작성하자
-//    @Test
-//    void likeList_Success(){
-//        Member member = Member.builder()
-//                .memberId(3L)
-//                .name("제로")
-//                .password("1111")
-//                .email("test@gmail.com")
-//                .build();
-//        Stadium stadium = Stadium.builder()
-//                .id(1L)
-//                .name("ESC 체육관")
-//                .phone("010-1234-5678")
-//                .address("경기도 광교")
-//                .detailAddress("123-456")
-//                .lat(36.5)
-//                .lnt(127.5)
-//                .weekdayPricePerHalfHour(19000)
-//                .holidayPricePerHalfHour(25000)
-//                .openTime(ReservingTime.RT19)
-//                .closeTime(ReservingTime.RT37)
-//                .build();
-//        StadiumLike like = StadiumLike.builder()
-//                .stadium(stadium)
-//                .member(member)
-//                .id(1L)
-//                .build();
-//        stadiumLikeRepository.save(like);
-//        Pageable page = Mockito.mock(Pageable.class);
-//        Page<StadiumLike> pageLike = Mockito.mock(Page.class);
-//        Mockito.when(stadiumLikeRepository.findAllByMember(member,page)).thenReturn(pageLike);
-//        //given
-//        given(stadiumRepository.findById(anyLong()))
-//                .willReturn(Optional.of(stadium));
-////        given(stadiumLikeRepository.findById(1L)).willReturn(Optional.of(like));
-//        given(stadiumLikeRepository.findAllByMember(member,page))
-//                .willReturn(pageLike);
-//        //when
-//        Page<StadiumLikeResponseDto> list =  stadiumLikeService.likeList(member,page);
-//        //then
-//        assertNotNull(list);
-//    }*/
 
 
 }

--- a/src/test/java/com/minwonhaeso/esc/stadium/service/StadiumPaymentServiceTest.java
+++ b/src/test/java/com/minwonhaeso/esc/stadium/service/StadiumPaymentServiceTest.java
@@ -1,6 +1,8 @@
 package com.minwonhaeso.esc.stadium.service;
 
 
+import com.minwonhaeso.esc.error.exception.AuthException;
+import com.minwonhaeso.esc.error.type.AuthErrorCode;
 import com.minwonhaeso.esc.member.model.entity.Member;
 import com.minwonhaeso.esc.stadium.facade.RedissonLockReservingTimeFacade;
 import com.minwonhaeso.esc.stadium.model.entity.Stadium;
@@ -26,7 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.minwonhaeso.esc.stadium.model.dto.StadiumPaymentDto.*;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
@@ -102,8 +104,61 @@ class StadiumPaymentServiceTest {
         given(stadiumItemRepository.findById(anyLong()))
                 .willReturn(Optional.of(item));
         //when
-        Map<String,String> map =  stadiumPaymentService.payment(member,stadiumId,request);
+
+        Map<String, String> map = stadiumPaymentService.payment(member, stadiumId, request);
         //then
         assertNotNull(map.get("successMessage"));
+    }
+
+    @DisplayName("결제 실패 - 예약자 이메일과 접속중인 유저의 email이 다르디")
+    @Test
+    void paymentFail_EmailNotMatch() {
+        Long stadiumId = 1L;
+        List<StadiumItem> likeList = new ArrayList<>();
+        StadiumItem item = StadiumItem.builder()
+                .name("축구공")
+                .price(30000)
+                .build();
+        likeList.add(item);
+        Member member = Member.builder()
+                .memberId(3L)
+                .name("제로")
+                .password("1111")
+                .email("test@gmail.com")
+                .build();
+        Stadium stadium = Stadium.builder()
+                .id(stadiumId)
+                .name("ESC 체육관")
+                .phone("010-1234-5678")
+                .address("경기도 광교")
+                .detailAddress("123-456")
+                .lat(36.5)
+                .lnt(127.5)
+                .weekdayPricePerHalfHour(19000)
+                .holidayPricePerHalfHour(25000)
+                .openTime(ReservingTime.RT19)
+                .closeTime(ReservingTime.RT37)
+                .rentalStadiumItems(likeList)
+                .build();
+        List<String> reservedTimes = new ArrayList<>();
+        List<ItemRequest> items = new ArrayList<>();
+        items.add(new ItemRequest(1L, 2));
+        reservedTimes.add("09:00");
+        PaymentRequest request = PaymentRequest.builder()
+                .date(LocalDate.now().plusDays(1))
+                .reservedTimes(reservedTimes)
+                .headCount(2)
+                .items(items)
+                .totalPrice(10000)
+                .email("testtest@gmail.com")
+                .paymentType("CARD")
+                .build();
+
+        //when
+        AuthException exception = assertThrows(
+                AuthException.class, () -> stadiumPaymentService.payment(member, stadiumId, request));
+        //then
+
+        assertEquals(exception.getErrorCode().getErrorMessage(), AuthErrorCode.EmailNotMatched.getErrorMessage());
     }
 }


### PR DESCRIPTION
### Background
---
* 초기 회원탈퇴 로직에는 유저는 예약현황, 판매자는 예약내역의 유무를 판단하지 않고 삭제하고 있었다.
* 기존 찜한 체육관 리스트 API에 filter가 없었다.
* 이메일 중복여부 판단 API에서 불필요하게 2번 검사했다.

### Change
---
* 회원탈퇴 API에서 유저는 예약 현황이 없을 경우, 판매자는 예약된 체육관이 없는 경우에만 계정 삭제가 가능하다.(status만 delete로 변경)
* Member와 Stadium에 status enum type이 추가되었다.
* 찜한 체육관 리스트 API를 Query dsl을 사용하여 filter를 추가했다.
* 이메일 중복여부 체크 API에서 불필요한 확인 로직 제거
* StadiumPaymentDto에서 @Data -> @Getter @Setter @AllArgsConstructor @NoArgsConstructor로 변경
* 테스트코드 추가

### Test
---
* 결제, 찜하기 관련 테스트코드 추가
* 기존 SpringbootTest를 사용해 테스트했던 member service 관련 test mock데이터로 변경

### Discuss
---
- 

